### PR TITLE
Implement focus mode on timer start

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/script.js
+++ b/script.js
@@ -309,6 +309,8 @@ class MyRPGLifeApp {
   startTimer() {
     this.timerState.isRunning = true;
     this.timerState.isPaused = false;
+
+    this.enterFocusMode();
     
     const startPauseBtn = document.getElementById('startPauseBtn');
     const startPauseText = document.getElementById('startPauseText');
@@ -331,6 +333,8 @@ class MyRPGLifeApp {
   pauseTimer() {
     this.timerState.isRunning = false;
     this.timerState.isPaused = true;
+
+    this.exitFocusMode();
     
     const startPauseBtn = document.getElementById('startPauseBtn');
     const startPauseText = document.getElementById('startPauseText');
@@ -347,6 +351,8 @@ class MyRPGLifeApp {
     this.timerState.isRunning = false;
     this.timerState.isPaused = false;
     this.timerState.remaining = this.timerState.duration;
+
+    this.exitFocusMode();
     
     const startPauseBtn = document.getElementById('startPauseBtn');
     const startPauseText = document.getElementById('startPauseText');
@@ -362,6 +368,8 @@ class MyRPGLifeApp {
 
   completeTimer() {
     clearInterval(this.timer);
+
+    this.exitFocusMode();
     
     const minutes = this.timerState.duration / 60;
     const xpGained = this.calculateFocusXP(minutes);
@@ -412,6 +420,20 @@ class MyRPGLifeApp {
       const offset = circumference - (progress / 100) * circumference;
       timerProgress.style.strokeDasharray = circumference;
       timerProgress.style.strokeDashoffset = offset;
+    }
+  }
+
+  enterFocusMode() {
+    const container = document.querySelector('.app-container');
+    if (container) {
+      container.classList.add('focus-mode');
+    }
+  }
+
+  exitFocusMode() {
+    const container = document.querySelector('.app-container');
+    if (container) {
+      container.classList.remove('focus-mode');
     }
   }
 

--- a/styles.css
+++ b/styles.css
@@ -2912,3 +2912,12 @@ select:focus {
   0% { transform: rotate(0deg); }
   100% { transform: rotate(360deg); }
 }
+
+/* Focus Mode */
+.app-container.focus-mode .sidebar,
+.app-container.focus-mode .main-content > .content-section:not(#focus) {
+  pointer-events: none;
+  filter: blur(3px);
+  opacity: 0.4;
+  transition: filter 0.3s, opacity 0.3s;
+}


### PR DESCRIPTION
## Summary
- disable sidebar and other sections when the focus timer is running
- style disabled UI with blur and opacity
- ignore `node_modules`

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68796edf0e208332a0dff4f8492fdceb