### PR TITLE
Add basic cloud sync with Supabase

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules/
+supabase-config.js

--- a/README.md
+++ b/README.md
@@ -127,17 +127,23 @@ Application immersive de gamification pour booster la productivité et la discip
 
 ## 💾 Sauvegarde
 
-- Données sauvegardées automatiquement dans le navigateur
+- Données sauvegardées automatiquement dans le navigateur et sur Supabase
 - Export/import des données disponible
 - Sauvegarde toutes les 30 secondes
-- Synchronisation multi-appareils via IndexedDB ou backend (à venir)
+- Synchronisation multi-appareils via Supabase
 
 ## 🔧 Configuration Technique
 
 - **Technologies**: HTML5, CSS3, JavaScript ES6+
-- **Stockage**: LocalStorage
+- **Stockage**: LocalStorage + Supabase
 - **Compatibilité**: Navigateurs modernes
 - **Responsive**: Optimisé pour PC
+
+### ⚙️ Configuration Supabase
+
+1. Copier `supabase-config.example.js` en `supabase-config.js`
+2. Remplacer les valeurs `SUPABASE_URL` et `SUPABASE_KEY` par celles de votre projet
+3. Créer une table `productivity` avec les colonnes `id` (int, primary key) et `data` (json)
 
 ## 🎯 Objectifs de Performance
 

--- a/index.html
+++ b/index.html
@@ -596,6 +596,9 @@
     <!-- Notifications -->
     <div class="notifications-container" id="notifications"></div>
 
-    <script src="script.js"></script>
+    <!-- Supabase library -->
+    <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js"></script>
+    <!-- Main application script as ES module -->
+    <script type="module" src="script.js"></script>
   </body>
 </html>

--- a/supabase-config.example.js
+++ b/supabase-config.example.js
@@ -1,0 +1,5 @@
+// Copiez ce fichier en `supabase-config.js` puis remplissez les valeurs
+// avec l'URL et la clé API publique (anon) de votre projet Supabase.
+
+export const SUPABASE_URL = 'https://YOUR_PROJECT.supabase.co';
+export const SUPABASE_KEY = 'YOUR_PUBLIC_ANON_KEY';


### PR DESCRIPTION
## Summary
- load Supabase library in `index.html` and use ES module script
- create configuration template for Supabase credentials
- ignore local `supabase-config.js`
- implement cloud loading/saving logic in `script.js`
- document Supabase setup in README

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687bc7a10cd4833281b0a71b2c082935