### PR TITLE
Enhance progression stats

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,9 @@ Application immersive de gamification pour booster la productivité et la discip
 - **Sommeil**: >7h avant 22h = +2 XP, avant minuit = +1 XP
 - **Punitions**: Instagram +1h = -3 XP, Musique +1h30 = -5 XP
 - **Quota minimum**: 15 XP/jour
+- Graphiques basés sur l'historique réel des sessions
+- Sélecteur 7/30 jours ou personnalisé
+- Barre de progression vers le prochain rang
 
 ### 🏆 Système de Rangs
 

--- a/styles.css
+++ b/styles.css
@@ -2132,6 +2132,22 @@ body {
   margin-bottom: 3rem;
 }
 
+.chart-range-select {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin-bottom: 1rem;
+}
+
+.chart-range-select select,
+.chart-range-select input {
+  padding: 0.3rem 0.5rem;
+  border-radius: 4px;
+  border: 1px solid var(--border-color);
+  background: var(--card-bg);
+  color: var(--text-primary);
+}
+
 .stats-cards {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
@@ -2277,6 +2293,32 @@ body {
   display: flex;
   flex-direction: column;
   gap: 1rem;
+}
+
+.next-rank-bar {
+  margin-bottom: 1rem;
+}
+
+.next-rank-info {
+  font-size: 0.9rem;
+  color: var(--text-secondary);
+  margin-bottom: 0.3rem;
+}
+
+.next-rank-progress {
+  width: 100%;
+  height: 8px;
+  background: var(--accent-bg);
+  border-radius: 4px;
+  overflow: hidden;
+}
+
+.next-rank-fill {
+  height: 100%;
+  background: var(--gradient-secondary);
+  border-radius: 4px;
+  width: 0;
+  transition: width 0.5s ease;
 }
 
 .rank-item {


### PR DESCRIPTION
## Summary
- use actual history in progression charts
- allow selecting timeframe (7, 30 or custom days)
- show progress bar to next rank
- save selected chart range in settings
- document the new progression features

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_687c0de3aa448332b448d18061868911