### PR TITLE
Add intensity label and reset tests

### DIFF
--- a/app.test.js
+++ b/app.test.js
@@ -1,0 +1,28 @@
+import { MyRPGLifeApp } from './script.js';
+
+class TestApp extends MyRPGLifeApp {
+  loadData() {
+    return {
+      totalXP: 0,
+      dailyXP: 0,
+      lastDailyReset: new Date().toDateString(),
+      projects: [],
+      focusSessions: [],
+      dailyActions: {},
+      xpHistory: [],
+      achievements: [],
+      weeklyReviews: [],
+      settings: { theme: 'default', soundNotifications: true, chartRange: 7 },
+    };
+  }
+  init() {}
+  updateUI() {}
+  saveData() {}
+}
+
+test('resetDailyStats resets dailyXP to zero', () => {
+  const app = new TestApp();
+  app.data.dailyXP = 42;
+  app.resetDailyStats();
+  expect(app.data.dailyXP).toBe(0);
+});

--- a/index.html
+++ b/index.html
@@ -596,6 +596,6 @@
     <!-- Notifications -->
     <div class="notifications-container" id="notifications"></div>
 
-    <script src="script.js"></script>
+    <script type="module" src="script.js"></script>
   </body>
 </html>

--- a/script.js
+++ b/script.js
@@ -1,4 +1,4 @@
-class MyRPGLifeApp {
+export class MyRPGLifeApp {
     constructor() {
     this.data = this.loadData();
     this.timer = null;
@@ -2027,6 +2027,10 @@ class MyRPGLifeApp {
 }
 
 // Initialize the app when DOM is loaded
-document.addEventListener('DOMContentLoaded', () => {
-  window.app = new MyRPGLifeApp();
-});
+if (typeof document !== 'undefined') {
+  document.addEventListener('DOMContentLoaded', () => {
+    window.app = new MyRPGLifeApp();
+  });
+}
+
+export default MyRPGLifeApp;

--- a/xp.test.js
+++ b/xp.test.js
@@ -1,4 +1,4 @@
-import { calculateFocusXP, calculateIntensityRate } from './xp.js';
+import { calculateFocusXP, calculateIntensityRate, getIntensityLabel } from './xp.js';
 
 test('calculateFocusXP returns bonus XP after mandatory sessions', () => {
   expect(calculateFocusXP(36, 2)).toBe(4); // 36 min -> baseXP=2, double=4
@@ -13,4 +13,22 @@ test('calculateIntensityRate averages last four weeks', () => {
     { percentage: 90 },
   ];
   expect(calculateIntensityRate(scores)).toBe(75);
+});
+
+test('getIntensityLabel returns correct label based on rate', () => {
+  const intensityLevels = [
+    { min: 0, max: 20, label: 'Errant du Néant' },
+    { min: 21, max: 40, label: 'Apprenti Perdu' },
+    { min: 41, max: 60, label: 'Disciple Motivé' },
+    { min: 61, max: 75, label: 'Adepte Déterminé' },
+    { min: 76, max: 85, label: 'Expert Focalisé' },
+    { min: 86, max: 95, label: 'Maître Discipliné' },
+    { min: 96, max: 99, label: 'Légende Vivante' },
+    { min: 100, max: 100, label: 'Transcendant' },
+  ];
+
+  expect(getIntensityLabel(10, intensityLevels)).toBe('Errant du Néant');
+  expect(getIntensityLabel(55, intensityLevels)).toBe('Disciple Motivé');
+  expect(getIntensityLabel(80, intensityLevels)).toBe('Expert Focalisé');
+  expect(getIntensityLabel(100, intensityLevels)).toBe('Transcendant');
 });


### PR DESCRIPTION
## Summary
- export `MyRPGLifeApp` to allow importing in tests
- load app script as ES module
- test `getIntensityLabel` at various rates
- test daily XP reset logic

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687c1f08d0d483328410ba88e11055f1