### PR TITLE
Add Supabase login and sync

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,7 +11,20 @@
     />
   </head>
   <body>
-    <div class="app-container">
+    <!-- Formulaire de connexion -->
+    <div id="loginContainer" class="login-container">
+      <form id="loginForm">
+        <h2>Connexion</h2>
+        <input type="email" id="loginEmail" placeholder="Email" required />
+        <input type="password" id="loginPassword" placeholder="Mot de passe" required />
+        <div class="login-actions">
+          <button type="submit">Se connecter</button>
+          <button type="button" id="signupBtn">Inscription</button>
+        </div>
+      </form>
+    </div>
+
+    <div class="app-container" id="appContainer" style="display: none;">
       <!-- Navigation -->
       <nav class="sidebar">
         <div class="logo">
@@ -596,6 +609,6 @@
     <!-- Notifications -->
     <div class="notifications-container" id="notifications"></div>
 
-    <script src="script.js"></script>
+    <script type="module" src="script.js"></script>
   </body>
 </html>

--- a/styles.css
+++ b/styles.css
@@ -3096,6 +3096,44 @@ select:focus {
   to { transform: translateY(-50%); }
 }
 
+/* ------- Authentification ------- */
+.login-container {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  min-height: 100vh;
+  background: var(--primary-bg);
+}
+
+.login-container form {
+  background: var(--card-bg);
+  padding: 2rem;
+  border-radius: 8px;
+  box-shadow: 0 0 10px rgba(0, 0, 0, 0.5);
+}
+
+.login-container input {
+  display: block;
+  width: 220px;
+  margin-bottom: 1rem;
+  padding: 0.5rem;
+  border: 1px solid var(--border-color);
+  border-radius: 4px;
+  background: var(--secondary-bg);
+  color: var(--text-primary);
+}
+
+.login-actions {
+  display: flex;
+  justify-content: space-between;
+}
+
+.login-actions button {
+  padding: 0.5rem 1rem;
+  cursor: pointer;
+}
+
 /* Focus Mode */
 .app-container.focus-mode .sidebar,
 .app-container.focus-mode .main-content > .content-section:not(#focus) {

--- a/supabase.js
+++ b/supabase.js
@@ -1,0 +1,33 @@
+import { createClient } from 'https://cdn.jsdelivr.net/npm/@supabase/supabase-js/+esm';
+
+// === Configuration Supabase ===
+// Remplacez les valeurs ci-dessous par l'URL et la clé API publique de votre projet.
+// Ces informations se trouvent dans la section "API" de votre tableau de bord Supabase.
+export const SUPABASE_URL = 'https://YOUR_PROJECT.supabase.co'; // <--- Collez ici l'URL de votre projet
+export const SUPABASE_ANON_KEY = 'YOUR_ANON_KEY'; // <--- Collez ici la clé publique (anon key)
+
+export const supabase = createClient(SUPABASE_URL, SUPABASE_ANON_KEY);
+
+// Récupère les données sauvegardées pour l'utilisateur
+export async function fetchUserData(userId) {
+  const { data, error } = await supabase
+    .from('user_data')
+    .select('data')
+    .eq('id', userId)
+    .single();
+  if (error) {
+    console.error('Supabase fetch error:', error);
+    return null;
+  }
+  return data ? data.data : null;
+}
+
+// Sauvegarde (upsert) les données de l'utilisateur
+export async function saveUserData(userId, data) {
+  const { error } = await supabase
+    .from('user_data')
+    .upsert({ id: userId, data });
+  if (error) {
+    console.error('Supabase save error:', error);
+  }
+}


### PR DESCRIPTION
## Summary
- integrate Supabase client for authentication and remote storage
- add login form before displaying the app
- store data remotely after each local save
- basic styles for authentication page

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687cb85ea9688332a4b37ac47c4081b2