### PR TITLE
Add detailed progression charts

### DIFF
--- a/script.js
+++ b/script.js
@@ -812,20 +812,29 @@ class MyRPGLifeApp {
   }
 
   // Modal functions
-  showModal(content) {
+  showModal(content, fullscreen = false) {
     const modal = document.getElementById('modal');
     const modalOverlay = document.getElementById('modalOverlay');
-    
+
     if (modal && modalOverlay) {
       modal.innerHTML = content;
+      if (fullscreen) {
+        modal.classList.add('fullscreen');
+      } else {
+        modal.classList.remove('fullscreen');
+      }
       modalOverlay.style.display = 'flex';
     }
   }
 
   closeModal() {
     const modalOverlay = document.getElementById('modalOverlay');
+    const modal = document.getElementById('modal');
     if (modalOverlay) {
       modalOverlay.style.display = 'none';
+    }
+    if (modal) {
+      modal.classList.remove('fullscreen');
     }
   }
 
@@ -1108,6 +1117,16 @@ class MyRPGLifeApp {
         this.data.settings.chartRange = this.chartRange;
         this.renderProgression();
       });
+    }
+
+    const xpChart = document.querySelector('.xp-chart');
+    if (xpChart) {
+      xpChart.addEventListener('click', () => this.showXPDetails());
+    }
+
+    const focusChart = document.querySelector('.focus-chart');
+    if (focusChart) {
+      focusChart.addEventListener('click', () => this.showFocusDetails());
     }
   }
 
@@ -1633,7 +1652,8 @@ class MyRPGLifeApp {
 
       days.push({
         day: dayName,
-        xp: dayXP
+        xp: dayXP,
+        date: date.toLocaleDateString('fr-FR')
       });
     }
 
@@ -1656,11 +1676,56 @@ class MyRPGLifeApp {
 
       days.push({
         day: dayName,
-        sessions: todaySessions
+        sessions: todaySessions,
+        date: date.toLocaleDateString('fr-FR')
       });
     }
 
     return days;
+  }
+
+  showXPDetails() {
+    const data = this.getLastDaysXP(this.chartRange);
+    const rows = data
+      .map(d => `<tr><td>${d.date}</td><td>${d.xp}</td></tr>`)
+      .join('');
+    const modalContent = `
+      <div class="modal-header">
+        <h3>Détails XP (${this.chartRange} jours)</h3>
+        <button class="modal-close" onclick="app.closeModal()">×</button>
+      </div>
+      <div class="modal-body">
+        <table class="detail-table">
+          <thead><tr><th>Date</th><th>XP</th></tr></thead>
+          <tbody>
+            ${rows}
+          </tbody>
+        </table>
+      </div>
+    `;
+    this.showModal(modalContent, true);
+  }
+
+  showFocusDetails() {
+    const data = this.getLastDaysFocus(this.chartRange);
+    const rows = data
+      .map(d => `<tr><td>${d.date}</td><td>${d.sessions}</td></tr>`)
+      .join('');
+    const modalContent = `
+      <div class="modal-header">
+        <h3>Détails Focus (${this.chartRange} jours)</h3>
+        <button class="modal-close" onclick="app.closeModal()">×</button>
+      </div>
+      <div class="modal-body">
+        <table class="detail-table">
+          <thead><tr><th>Date</th><th>Sessions</th></tr></thead>
+          <tbody>
+            ${rows}
+          </tbody>
+        </table>
+      </div>
+    `;
+    this.showModal(modalContent, true);
   }
 
   renderRanksProgression() {

--- a/styles.css
+++ b/styles.css
@@ -1517,6 +1517,13 @@ body {
   animation: modalSlideIn 0.3s ease;
 }
 
+.modal.fullscreen {
+  max-width: none;
+  width: 95%;
+  max-height: none;
+  height: 90vh;
+}
+
 @keyframes modalSlideIn {
   from {
     opacity: 0;
@@ -2278,6 +2285,11 @@ body {
   border-radius: 16px;
   padding: 2rem;
   border: 1px solid var(--border-color);
+}
+
+.xp-chart,
+.focus-chart {
+  cursor: pointer;
 }
 
 .chart-container h4 {
@@ -3128,4 +3140,21 @@ select:focus {
   filter: blur(3px);
   opacity: 0.4;
   transition: filter 0.3s, opacity 0.3s;
+}
+
+.detail-table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.detail-table th,
+.detail-table td {
+  padding: 0.5rem 0.75rem;
+  border-bottom: 1px solid var(--border-color);
+  text-align: left;
+}
+
+.detail-table th {
+  background: var(--accent-bg);
+  color: var(--text-primary);
 }


### PR DESCRIPTION
## Summary
- support fullscreen modal rendering in `showModal`
- include dates in progression data
- add detailed XP and focus views with modal display
- make charts clickable and add pointer styling
- style fullscreen modals and detail tables

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_687d0a1df1dc833298836de82f6ae8d9