### PR TITLE
Add animated achievements and XP pop

### DIFF
--- a/index.html
+++ b/index.html
@@ -313,6 +313,7 @@
                       +2.8 XP
                     </div>
                   </div>
+                  <div id="xpPopContainer" class="xp-pop-zone"></div>
                 </div>
 
                 <!-- Contrôles de durée -->

--- a/styles.css
+++ b/styles.css
@@ -3239,3 +3239,81 @@ select:focus {
 .detail-table tbody tr:hover {
   transform: translateX(5px);
 }
+
+/* XP Popup Animation */
+.xp-pop-zone {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  pointer-events: none;
+}
+
+.xp-popup {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  font-size: 1.2rem;
+  font-weight: 700;
+  color: var(--accent-color);
+  text-shadow: 0 0 6px rgba(255, 255, 255, 0.8);
+  animation: xp-pop 1s ease-out forwards;
+}
+
+@keyframes xp-pop {
+  0% {
+    opacity: 1;
+    transform: translate(-50%, -50%) scale(1);
+  }
+  100% {
+    opacity: 0;
+    transform: translate(-50%, -120%) scale(1.5);
+  }
+}
+
+/* Achievement Tiers */
+.achievement-card.tier-medium {
+  border-color: #3b82f6;
+  box-shadow: 0 0 10px rgba(59, 130, 246, 0.4);
+}
+
+.achievement-card.tier-premium {
+  border-color: #8b5cf6;
+  box-shadow: 0 0 20px rgba(139, 92, 246, 0.6);
+  animation: glowPulse 3s infinite ease-in-out;
+}
+
+.achievement-card.tier-prestigious {
+  border-color: #f59e0b;
+  box-shadow: 0 0 20px rgba(245, 158, 11, 0.8), 0 0 40px rgba(245, 158, 11, 0.6);
+  position: relative;
+  overflow: hidden;
+}
+
+.achievement-card.tier-prestigious::after {
+  content: '';
+  position: absolute;
+  inset: -50%;
+  background: radial-gradient(circle, rgba(245, 158, 11, 0.2), transparent 70%);
+  animation: rotateGlow 6s linear infinite;
+}
+
+@keyframes glowPulse {
+  from {
+    box-shadow: 0 0 10px rgba(139, 92, 246, 0.4);
+  }
+  to {
+    box-shadow: 0 0 20px rgba(139, 92, 246, 1);
+  }
+}
+
+@keyframes rotateGlow {
+  from {
+    transform: rotate(0deg);
+  }
+  to {
+    transform: rotate(360deg);
+  }
+}


### PR DESCRIPTION
## Summary
- add XP popup zone in focus timer
- implement XP pop animation and achievement glow effects
- add helper functions for streak calculations
- expand achievements list with medium, premium and prestigious tiers

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687e8ad0337c8332b9c2c86dc55749c3