### PR TITLE
Enhance achievements section with tiers

### DIFF
--- a/script.js
+++ b/script.js
@@ -988,6 +988,17 @@ class MyRPGLifeApp {
     const achievements = this.getAchievements();
     const unlockedCount = achievements.filter(a => a.unlocked).length;
 
+    const tiers = {
+      'tier-easy': 'Facile',
+      'tier-medium': 'Intermédiaire',
+      'tier-hard': 'Difficile'
+    };
+
+    const grouped = Object.keys(tiers).reduce((acc, key) => {
+      acc[key] = achievements.filter(a => a.tier === key);
+      return acc;
+    }, {});
+
     achievementsContent.innerHTML = `
       <div class="achievements-header">
         <div class="achievements-stats">
@@ -1003,24 +1014,26 @@ class MyRPGLifeApp {
           </div>
         </div>
       </div>
-      
-      <div class="achievements-grid">
-        ${achievements.map(achievement => `
-          <div class="achievement-card ${achievement.tier} ${achievement.unlocked ? 'unlocked' : 'locked'}">
-            <div class="achievement-icon">${achievement.icon}</div>
-            <div class="achievement-info">
-              <h4>${achievement.name}</h4>
-              <p>${achievement.description}</p>
-              <div class="achievement-reward">+${achievement.xp} XP</div>
-              ${achievement.unlocked ? 
-                `<div class="achievement-date">Débloqué le ${new Date(achievement.unlockedAt).toLocaleDateString()}</div>` :
-                `<div class="achievement-progress-text">${achievement.progress || '0'}/${achievement.target || '?'}</div>`
-              }
+      ${Object.keys(tiers).map(tier => `
+        <h3 class="achievement-group-title">${tiers[tier]}</h3>
+        <div class="achievements-grid">
+          ${grouped[tier].map(achievement => `
+            <div class="achievement-card ${tier} ${achievement.unlocked ? 'unlocked' : 'locked'}">
+              <div class="achievement-icon">${achievement.icon}</div>
+              <div class="achievement-info">
+                <h4>${achievement.name}</h4>
+                <p>${achievement.description}</p>
+                <div class="achievement-reward">+${achievement.xp} XP</div>
+                ${achievement.unlocked ?
+                  `<div class="achievement-date">Débloqué le ${new Date(achievement.unlockedAt).toLocaleDateString()}</div>` :
+                  `<div class="achievement-progress-text">${achievement.progress || '0'}/${achievement.target || '?'}</div>`
+                }
+              </div>
+              ${achievement.unlocked ? '<div class="achievement-badge">✓</div>' : ''}
             </div>
-            ${achievement.unlocked ? '<div class="achievement-badge">✓</div>' : ''}
-          </div>
-        `).join('')}
-      </div>
+          `).join('')}
+        </div>
+      `).join('')}
     `;
   }
 
@@ -1563,7 +1576,7 @@ class MyRPGLifeApp {
         description: 'Complétez votre première session de focus',
         icon: '🎯',
         xp: 10,
-        tier: 'basic',
+        tier: 'tier-easy',
         unlocked: this.data.focusSessions.length > 0,
         unlockedAt: this.data.focusSessions[0]?.date
       },
@@ -1573,7 +1586,7 @@ class MyRPGLifeApp {
         description: 'Atteignez 15 XP en une journée',
         icon: '⚡',
         xp: 15,
-        tier: 'basic',
+        tier: 'tier-easy',
         unlocked: this.data.dailyXP >= 15,
         progress: this.data.dailyXP,
         target: 15
@@ -1584,7 +1597,7 @@ class MyRPGLifeApp {
         description: '10 sessions de focus',
         icon: '🏹',
         xp: 25,
-        tier: 'medium',
+        tier: 'tier-medium',
         unlocked: this.data.focusSessions.length >= 10,
         progress: this.data.focusSessions.length,
         target: 10
@@ -1595,7 +1608,7 @@ class MyRPGLifeApp {
         description: '7 jours consécutifs à 15+ XP',
         icon: '⚔️',
         xp: 50,
-        tier: 'medium',
+        tier: 'tier-medium',
         unlocked: this.calculateStreak() >= 7,
         progress: this.calculateStreak(),
         target: 7
@@ -1606,7 +1619,7 @@ class MyRPGLifeApp {
         description: '7 jours consécutifs de sport',
         icon: '🏃',
         xp: 30,
-        tier: 'medium',
+        tier: 'tier-medium',
         unlocked: this.getSportStreak() >= 7,
         progress: this.getSportStreak(),
         target: 7
@@ -1617,7 +1630,7 @@ class MyRPGLifeApp {
         description: "Réaliser 3 jours d\u2019affilée avec les 2 blocs obligatoires",
         icon: '🛡️',
         xp: 25,
-        tier: 'medium',
+        tier: 'tier-medium',
         unlocked: this.getBlocksStreak() >= 3,
         progress: this.getBlocksStreak(),
         target: 3
@@ -1628,7 +1641,7 @@ class MyRPGLifeApp {
         description: '50 sessions de focus',
         icon: '🧘',
         xp: 100,
-        tier: 'premium',
+        tier: 'tier-hard',
         unlocked: this.data.focusSessions.length >= 50,
         progress: this.data.focusSessions.length,
         target: 50
@@ -1639,7 +1652,7 @@ class MyRPGLifeApp {
         description: 'Atteindre 1000 XP total',
         icon: '💠',
         xp: 150,
-        tier: 'premium',
+        tier: 'tier-hard',
         unlocked: this.data.totalXP >= 1000,
         progress: this.data.totalXP,
         target: 1000
@@ -1650,7 +1663,7 @@ class MyRPGLifeApp {
         description: '4h de focus en une journée',
         icon: '🏅',
         xp: 200,
-        tier: 'premium',
+        tier: 'tier-hard',
         unlocked: this.getMaxDailyFocus() >= 240,
         progress: this.getMaxDailyFocus(),
         target: 240
@@ -1661,7 +1674,7 @@ class MyRPGLifeApp {
         description: "Atteignez le rang S",
         icon: '👑',
         xp: 50,
-        tier: 'premium',
+        tier: 'tier-hard',
         unlocked: this.data.totalXP >= 600,
         progress: this.data.totalXP,
         target: 600
@@ -1672,7 +1685,7 @@ class MyRPGLifeApp {
         description: '100 sessions de focus',
         icon: '🌠',
         xp: 300,
-        tier: 'prestigious',
+        tier: 'tier-hard',
         unlocked: this.data.focusSessions.length >= 100,
         progress: this.data.focusSessions.length,
         target: 100
@@ -1683,7 +1696,7 @@ class MyRPGLifeApp {
         description: 'Terminer une saison avec rang S+',
         icon: '🏆',
         xp: 500,
-        tier: 'prestigious',
+        tier: 'tier-hard',
         unlocked: this.hasSeasonRankSPlus(),
         progress: this.data.totalXP,
         target: null

--- a/styles.css
+++ b/styles.css
@@ -2045,6 +2045,17 @@ body {
 .achievements-container {
   max-width: 1200px;
   margin: 0 auto;
+  position: relative;
+  animation: fadeInUp 0.6s ease;
+}
+
+.achievements-container::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(circle at top left, rgba(79, 172, 254, 0.15), transparent 70%);
+  animation: rotateGlowBg 12s linear infinite;
+  z-index: -1;
 }
 
 .achievements-container h2 {
@@ -2102,6 +2113,18 @@ body {
   display: grid;
   grid-template-columns: repeat(auto-fill, minmax(350px, 1fr));
   gap: 1.5rem;
+}
+
+.achievement-group-title {
+  margin: 2rem 0 1rem;
+  text-align: center;
+  font-family: 'Orbitron', monospace;
+  font-size: 1.8rem;
+  background: var(--gradient-secondary);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+  animation: gradientShift 6s ease infinite;
 }
 
 .achievement-card {
@@ -3274,25 +3297,24 @@ select:focus {
 }
 
 /* Achievement Tiers */
+.achievement-card.tier-easy {
+  border-color: var(--success-color-bright);
+}
+
 .achievement-card.tier-medium {
   border-color: #3b82f6;
   box-shadow: 0 0 10px rgba(59, 130, 246, 0.4);
 }
 
-.achievement-card.tier-premium {
-  border-color: #8b5cf6;
-  box-shadow: 0 0 20px rgba(139, 92, 246, 0.6);
-  animation: glowPulse 3s infinite ease-in-out;
-}
-
-.achievement-card.tier-prestigious {
-  border-color: #f59e0b;
+.achievement-card.tier-hard {
+  border-color: var(--accent-color);
   box-shadow: 0 0 20px rgba(245, 158, 11, 0.8), 0 0 40px rgba(245, 158, 11, 0.6);
+  animation: glowPulse 3s infinite ease-in-out;
   position: relative;
   overflow: hidden;
 }
 
-.achievement-card.tier-prestigious::after {
+.achievement-card.tier-hard::after {
   content: '';
   position: absolute;
   inset: -50%;
@@ -3316,4 +3338,9 @@ select:focus {
   to {
     transform: rotate(360deg);
   }
+}
+
+@keyframes rotateGlowBg {
+  from { transform: rotate(0deg); }
+  to { transform: rotate(360deg); }
 }


### PR DESCRIPTION
## Summary
- group achievements into easy, medium and hard
- add flashy styles for tiered cards
- animate achievements container

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_687e8d7b1cd88332b1d5c75863db335c