### PR TITLE
Add season reset logic

### DIFF
--- a/index.html
+++ b/index.html
@@ -114,6 +114,12 @@
               </div>
             </div>
 
+            <!-- Saison précédente -->
+            <div class="last-season-card" id="lastSeasonCard" style="display: none">
+              <h3>Rang Saison Précédente</h3>
+              <div class="last-season-rank" id="lastSeasonRank">-</div>
+            </div>
+
             <!-- Taux d'Intensité -->
             <div class="intensity-card">
               <h3>Taux d'Intensité</h3>
@@ -586,6 +592,13 @@
           </div>
         </section>
       </main>
+    </div>
+
+    <!-- Écran de démarrage -->
+    <div class="start-overlay" id="startOverlay" style="display: none">
+      <button id="startAdventureBtn" class="start-adventure-btn">
+        Commencer l'aventure
+      </button>
     </div>
 
     <!-- Modales -->

--- a/styles.css
+++ b/styles.css
@@ -691,6 +691,19 @@ body {
   width: 0%;
 }
 
+/* Carte de la saison pr\E9c\E9dente */
+.last-season-card h3 {
+  color: var(--secondary-color);
+  margin-bottom: 1rem;
+  font-size: 1.2rem;
+  font-weight: 600;
+}
+
+.last-season-rank {
+  text-align: center;
+  font-size: 1.5rem;
+}
+
 /* Focus Timer Section */
 .focus-container {
   max-width: 1200px;
@@ -1534,6 +1547,36 @@ body {
 
 .modal-overlay.show {
   opacity: 1;
+}
+
+/* Overlay de d\E9marrage */
+.start-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: var(--gradient-cosmos);
+  display: none;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+  opacity: 1;
+  transition: opacity 0.5s ease;
+}
+
+.start-overlay.fade-out {
+  opacity: 0;
+}
+
+.start-adventure-btn {
+  padding: 1rem 2rem;
+  font-size: 1.5rem;
+  border: none;
+  border-radius: 12px;
+  background: var(--gradient-primary);
+  color: white;
+  cursor: pointer;
 }
 
 .modal {


### PR DESCRIPTION
## Summary
- add start overlay screen
- implement two-season cycle with automatic reset
- show last season rank in dashboard

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_687ea895becc8332b5ca147ccd81b7e1