### PR TITLE
Add weekly review detail modal

### DIFF
--- a/script.js
+++ b/script.js
@@ -988,8 +988,9 @@ class MyRPGLifeApp {
       </div>
     `;
 
-    // Setup sliders
+    // Setup sliders and history events
     this.setupWeeklySliders();
+    this.setupWeeklyHistoryEvents();
   }
 
   renderAchievements() {
@@ -1572,9 +1573,14 @@ class MyRPGLifeApp {
     if (this.data.weeklyReviews.length === 0) {
       return '<p class="no-reviews">Aucun bilan effectué pour le moment</p>';
     }
-    
-    return this.data.weeklyReviews.slice(-8).reverse().map(review => `
-      <div class="review-card">
+
+    return this.data.weeklyReviews
+      .slice(-8)
+      .reverse()
+      .map(review => {
+        const index = this.data.weeklyReviews.indexOf(review);
+        return `
+      <div class="review-card" data-index="${index}">
         <div class="review-header">
           <span class="review-week">Semaine ${review.week}</span>
           <span class="review-score">${review.totalScore}/50</span>
@@ -1585,8 +1591,54 @@ class MyRPGLifeApp {
           </div>
           <span>${Math.round(review.percentage)}%</span>
         </div>
+      </div>`;
+      })
+      .join('');
+  }
+
+  setupWeeklyHistoryEvents() {
+    const cards = document.querySelectorAll('.review-card');
+    cards.forEach(card => {
+      card.addEventListener('click', () => {
+        const index = parseInt(card.dataset.index, 10);
+        const review = this.data.weeklyReviews[index];
+        if (review) {
+          this.showWeeklyReviewDetails(review);
+        }
+      });
+    });
+  }
+
+  showWeeklyReviewDetails(review) {
+    const scores = review.scores;
+    const rows = [
+      ['🎯 Productivité et focus', scores.productivity],
+      ['💪 Santé et bien-être', scores.health],
+      ['🎨 Créativité et apprentissage', scores.creativity],
+      ['🤝 Relations sociales', scores.social],
+      ['😊 Satisfaction générale', scores.satisfaction]
+    ]
+      .map(
+        r => `<tr><td>${r[0]}</td><td>${r[1]}/10</td></tr>`
+      )
+      .join('');
+    const modalContent = `
+      <div class="modal-header">
+        <h3>Détails Bilan - Semaine ${review.week}</h3>
+        <button class="modal-close" onclick="app.closeModal()">×</button>
       </div>
-    `).join('');
+      <div class="modal-body">
+        <table class="detail-table">
+          <tbody>
+            ${rows}
+          </tbody>
+        </table>
+        <div class="reflection-text">
+          <h4>Réflexion</h4>
+          <p>${review.reflection ? review.reflection.replace(/\n/g, '<br>') : 'Aucune réflexion enregistrée.'}</p>
+        </div>
+      </div>`;
+    this.showModal(modalContent, true);
   }
 
   getAchievements() {

--- a/styles.css
+++ b/styles.css
@@ -2061,6 +2061,7 @@ body {
   padding: 1rem;
   border: 1px solid var(--border-color);
   transition: all 0.3s ease;
+  cursor: pointer;
 }
 
 .review-card:hover {
@@ -2104,6 +2105,20 @@ body {
   background: var(--gradient-primary);
   border-radius: 4px;
   transition: width 0.5s ease;
+}
+
+.reflection-text {
+  margin-top: 1.5rem;
+  background: var(--accent-bg);
+  padding: 1rem;
+  border-radius: 8px;
+  border: 1px solid var(--border-color);
+  white-space: pre-line;
+}
+
+.reflection-text h4 {
+  margin-bottom: 0.5rem;
+  color: var(--text-primary);
 }
 
 /* Achievements Styles */


### PR DESCRIPTION
## Summary
- enable clicking on weekly review cards
- show ratings and reflection in a modal
- minor style tweaks for review cards and reflection display

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_687ebb5a0da483328b66f6eb67693a45