### PR TITLE
Improve Google Calendar integration and break display

### DIFF
--- a/index.html
+++ b/index.html
@@ -353,6 +353,9 @@
                   </button>
                 </div>
 
+                <!-- Information pauses automatiques -->
+                <div class="break-info" id="breakInfo"></div>
+
                 <!-- Options avec design amélioré -->
                 <div class="timer-options">
                   <div class="option-item">
@@ -363,7 +366,6 @@
                         >Pauses automatiques (5min/25min)</span
                       >
                     </label>
-                    <div class="break-info" id="breakInfo"></div>
                   </div>
                   <div class="option-item">
                     <label class="futuristic-toggle">

--- a/main.js
+++ b/main.js
@@ -1,4 +1,4 @@
-const { app, BrowserWindow, ipcMain } = require('electron');
+const { app, BrowserWindow, ipcMain, shell } = require('electron');
 const path = require('path');
 const fs = require('fs');
 const { google } = require('googleapis');
@@ -120,6 +120,14 @@ ipcMain.handle('disconnect-google-calendar', () => {
     if (oauth2Client) {
       oauth2Client.setCredentials({});
     }
+    return true;
+  } catch {
+    return false;
+  }
+});
+ipcMain.handle('open-external', async (event, url) => {
+  try {
+    await shell.openExternal(url);
     return true;
   } catch {
     return false;

--- a/main.js
+++ b/main.js
@@ -104,6 +104,14 @@ async function addFocusSessionToCalendar(session) {
 app.whenReady().then(createWindow);
 
 ipcMain.handle('connect-google-calendar', authenticateWithGoogle);
+ipcMain.handle('is-google-connected', () => {
+  try {
+    const token = fs.readFileSync(TOKEN_PATH, 'utf8');
+    return !!JSON.parse(token).access_token;
+  } catch {
+    return false;
+  }
+});
 ipcMain.handle('log-focus-session', async (event, session) => {
   return addFocusSessionToCalendar(session);
 });

--- a/main.js
+++ b/main.js
@@ -112,6 +112,19 @@ ipcMain.handle('is-google-connected', () => {
     return false;
   }
 });
+ipcMain.handle('disconnect-google-calendar', () => {
+  try {
+    if (fs.existsSync(TOKEN_PATH)) {
+      fs.unlinkSync(TOKEN_PATH);
+    }
+    if (oauth2Client) {
+      oauth2Client.setCredentials({});
+    }
+    return true;
+  } catch {
+    return false;
+  }
+});
 ipcMain.handle('log-focus-session', async (event, session) => {
   return addFocusSessionToCalendar(session);
 });

--- a/preload.js
+++ b/preload.js
@@ -1,9 +1,9 @@
-const { contextBridge, ipcRenderer, shell } = require('electron');
+const { contextBridge, ipcRenderer } = require('electron');
 
 contextBridge.exposeInMainWorld('electronAPI', {
   connectGoogleCalendar: () => ipcRenderer.invoke('connect-google-calendar'),
   logFocusSession: session => ipcRenderer.invoke('log-focus-session', session),
   isGoogleConnected: () => ipcRenderer.invoke('is-google-connected'),
   disconnectGoogleCalendar: () => ipcRenderer.invoke('disconnect-google-calendar'),
-  openExternal: url => shell.openExternal(url)
+  openExternal: url => ipcRenderer.invoke('open-external', url)
 });

--- a/preload.js
+++ b/preload.js
@@ -1,6 +1,8 @@
-const { contextBridge, ipcRenderer } = require('electron');
+const { contextBridge, ipcRenderer, shell } = require('electron');
 
 contextBridge.exposeInMainWorld('electronAPI', {
   connectGoogleCalendar: () => ipcRenderer.invoke('connect-google-calendar'),
-  logFocusSession: session => ipcRenderer.invoke('log-focus-session', session)
+  logFocusSession: session => ipcRenderer.invoke('log-focus-session', session),
+  isGoogleConnected: () => ipcRenderer.invoke('is-google-connected'),
+  openExternal: url => shell.openExternal(url)
 });

--- a/preload.js
+++ b/preload.js
@@ -4,5 +4,6 @@ contextBridge.exposeInMainWorld('electronAPI', {
   connectGoogleCalendar: () => ipcRenderer.invoke('connect-google-calendar'),
   logFocusSession: session => ipcRenderer.invoke('log-focus-session', session),
   isGoogleConnected: () => ipcRenderer.invoke('is-google-connected'),
+  disconnectGoogleCalendar: () => ipcRenderer.invoke('disconnect-google-calendar'),
   openExternal: url => shell.openExternal(url)
 });

--- a/script.js
+++ b/script.js
@@ -346,6 +346,8 @@ class MyRPGLifeApp {
     this.timerState.totalBreaks = Math.floor(this.timerState.duration / (25 * 60));
     this.timerState.breakCount = this.timerState.breakCount || 0;
 
+    this.updateBreakInfo();
+
     this.timerState.startTimestamp = Date.now() -
       (this.timerState.duration - this.timerState.remaining) * 1000;
 
@@ -438,6 +440,7 @@ class MyRPGLifeApp {
     
     clearInterval(this.timer);
     this.updateTimerDisplay();
+    this.updateBreakInfo();
   }
 
   completeTimer() {
@@ -514,8 +517,12 @@ class MyRPGLifeApp {
     const autoBreaksToggle = document.getElementById('autoBreaks');
     if (!info || !autoBreaksToggle) return;
     if (autoBreaksToggle.checked) {
-      const breaks = Math.floor(this.timerState.duration / (25 * 60));
-      info.textContent = `${breaks} pause${breaks > 1 ? 's' : ''} prévues`;
+      const total = Math.floor(this.timerState.duration / (25 * 60));
+      const remaining = total - this.timerState.breakCount;
+      const label = this.timerState.isRunning || this.timerState.breakCount > 0
+        ? `${remaining} pause${remaining > 1 ? 's' : ''} restantes pour la session`
+        : `${total} pause${total > 1 ? 's' : ''} prévues`;
+      info.innerHTML = `<span class="remaining">${label}</span>`;
     } else {
       info.textContent = '';
     }
@@ -1273,9 +1280,13 @@ class MyRPGLifeApp {
       .sort((a, b) => b.totalTime - a.totalTime);
   }
 
-  renderSettings() {
+  async renderSettings() {
     const settingsContent = document.getElementById('settingsContent');
     if (!settingsContent) return;
+
+    const googleConnected = window.electronAPI?.isGoogleConnected
+      ? await window.electronAPI.isGoogleConnected()
+      : false;
 
     settingsContent.innerHTML = `
       <div class="settings-grid">
@@ -1433,7 +1444,10 @@ class MyRPGLifeApp {
             <h3>Google Calendar</h3>
           </div>
           <div class="settings-content">
-            <button id="connectGoogleCalendarBtn" class="data-btn connect-btn">Connecter Google Calendar</button>
+            ${googleConnected
+              ? `<div class="connected-status"><span class="status-icon">🟢</span> Compte Google Connecté</div>
+                 <button id="openGoogleCalendarBtn" class="data-btn open-btn">Ouvrir Google Calendar</button>`
+              : `<button id="connectGoogleCalendarBtn" class="data-btn connect-btn">Connecter Google Calendar</button>`}
           </div>
         </div>
         
@@ -2112,9 +2126,17 @@ class MyRPGLifeApp {
         const ok = await window.electronAPI.connectGoogleCalendar();
         if (ok) {
           this.showNotification('Google Calendar connecté', 'success');
+          this.renderSettings();
         } else {
           this.showNotification('Erreur de connexion Google', 'error');
         }
+      });
+    }
+
+    const openBtn = document.getElementById('openGoogleCalendarBtn');
+    if (openBtn && window.electronAPI) {
+      openBtn.addEventListener('click', () => {
+        window.electronAPI.openExternal('https://calendar.google.com');
       });
     }
 

--- a/script.js
+++ b/script.js
@@ -2139,7 +2139,9 @@ class MyRPGLifeApp {
     const openBtn = document.getElementById('openGoogleCalendarBtn');
     if (openBtn && window.electronAPI) {
       openBtn.addEventListener('click', () => {
-        window.electronAPI.openExternal('https://calendar.google.com');
+        window.electronAPI.openExternal(
+          'https://calendar.google.com/calendar/u/0/r'
+        );
       });
     }
 

--- a/script.js
+++ b/script.js
@@ -1446,8 +1446,11 @@ class MyRPGLifeApp {
           <div class="settings-content">
             ${googleConnected
               ? `<div class="connected-status"><span class="status-icon">🟢</span> Compte Google Connecté</div>
-                 <button id="openGoogleCalendarBtn" class="data-btn open-btn">Ouvrir Google Calendar</button>`
-              : `<button id="connectGoogleCalendarBtn" class="data-btn connect-btn">Connecter Google Calendar</button>`}
+                 <div class="gc-actions">
+                   <button id="openGoogleCalendarBtn" class="data-btn open-btn">Ouvrir Google Calendar</button>
+                   <button id="disconnectGoogleCalendarBtn" class="data-btn disconnect-btn">Se déconnecter</button>
+                 </div>`
+              : `<button id="connectGoogleCalendarBtn" class="data-btn connect-btn">Se connecter à Google Calendar</button>`}
           </div>
         </div>
         
@@ -2137,6 +2140,19 @@ class MyRPGLifeApp {
     if (openBtn && window.electronAPI) {
       openBtn.addEventListener('click', () => {
         window.electronAPI.openExternal('https://calendar.google.com');
+      });
+    }
+
+    const disconnectBtn = document.getElementById('disconnectGoogleCalendarBtn');
+    if (disconnectBtn && window.electronAPI) {
+      disconnectBtn.addEventListener('click', async () => {
+        const ok = await window.electronAPI.disconnectGoogleCalendar();
+        if (ok) {
+          this.showNotification('Google Calendar déconnecté', 'success');
+          this.renderSettings();
+        } else {
+          this.showNotification('Erreur de déconnexion Google', 'error');
+        }
       });
     }
 

--- a/styles.css
+++ b/styles.css
@@ -1010,6 +1010,16 @@ body {
   background: rgba(0, 212, 255, 0.1);
 }
 
+.disconnect-btn:hover {
+  border-color: var(--error-color);
+  background: rgba(239, 68, 68, 0.1);
+}
+
+.gc-actions {
+  display: flex;
+  gap: 0.5rem;
+}
+
 /* Focus Stats Panel */
 .focus-stats-panel {
   background: var(--card-bg);

--- a/styles.css
+++ b/styles.css
@@ -986,8 +986,28 @@ body {
 
 .break-info {
   text-align: center;
-  font-size: 0.9rem;
+  font-size: 0.95rem;
   color: var(--text-secondary);
+  margin-top: 0.5rem;
+}
+
+.break-info .remaining {
+  color: var(--primary-color);
+  font-weight: 600;
+}
+
+.connected-status {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin-bottom: 0.5rem;
+  color: var(--success-color);
+  font-weight: 600;
+}
+
+.open-btn:hover {
+  border-color: var(--primary-color);
+  background: rgba(0, 212, 255, 0.1);
 }
 
 /* Focus Stats Panel */


### PR DESCRIPTION
## Summary
- show Google account connection status with option to open Calendar
- expose new IPC handlers and preload APIs
- style connected status and better break info placement
- display remaining automatic breaks dynamically

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_687ed84bfe9883328382ac87aea49949