### PR TITLE
Fix weekly XP reward and rank display

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,3 +1,3 @@
-export default {
-  testEnvironment: 'node',
+module.exports = {
+  testEnvironment: 'node'
 };

--- a/script.js
+++ b/script.js
@@ -1612,6 +1612,8 @@ class MyRPGLifeApp {
     this.data.weeklyReviews.push(review);
     this.addXP(5, 'Bilan Hebdomadaire');
     this.showNotification('✨ Bilan hebdomadaire terminé ! +5 XP', 'success');
+    this.updateUI();
+    this.saveData();
     this.startWeeklyCountdown();
     this.renderWeeklyReview();
   }
@@ -2004,21 +2006,23 @@ class MyRPGLifeApp {
       { name: 'Élu du Destin', xp: 750, badge: 'SSS', avatar: '🌙' }
     ];
     
-    return ranks.map(rank => {
-      const isUnlocked = this.data.totalXP >= rank.xp;
-      const isCurrent = this.getCurrentRank().name === rank.name;
-      
-      return `
-        <div class="rank-item ${isUnlocked ? 'unlocked' : 'locked'} ${isCurrent ? 'current' : ''}">
-          <div class="rank-avatar">${rank.avatar}</div>
-          <div class="rank-info">
-            <div class="rank-name">${rank.name}</div>
-            <div class="rank-requirement">${rank.xp} XP</div>
+    return ranks
+      .map(rank => {
+        const isUnlocked = this.data.totalXP >= rank.xp;
+        const isCurrent = this.getCurrentRank().name === rank.name;
+        const badgeClass = `rank-${rank.badge.toLowerCase()}`;
+
+        return `
+          <div class="rank-item ${badgeClass} ${isUnlocked ? 'unlocked' : 'locked'} ${isCurrent ? 'current' : ''}">
+            <div class="rank-avatar">${rank.avatar}</div>
+            <div class="rank-info">
+              <div class="rank-name">${rank.name} <span class="rank-class">${rank.badge}</span></div>
+              <div class="rank-requirement">${rank.xp} XP</div>
+            </div>
           </div>
-          <div class="rank-badge">${rank.badge}</div>
-        </div>
-      `;
-    }).join('');
+        `;
+      })
+      .join('');
   }
 
   renderRankProgressBar() {

--- a/styles.css
+++ b/styles.css
@@ -2542,12 +2542,10 @@ body {
 }
 
 .rank-item.unlocked {
-  background: rgba(16, 185, 129, 0.1);
   border-color: var(--success-color);
 }
 
 .rank-item.current {
-  background: rgba(0, 212, 255, 0.1);
   border-color: var(--primary-color);
   box-shadow: 0 0 15px rgba(0, 212, 255, 0.2);
 }
@@ -2576,14 +2574,70 @@ body {
   font-size: 0.9rem;
 }
 
-.rank-badge {
+.rank-class {
   background: var(--accent-bg);
   color: var(--text-primary);
-  padding: 0.5rem;
-  border-radius: 8px;
+  padding: 0.25rem 0.5rem;
+  border-radius: 6px;
   font-weight: bold;
-  min-width: 40px;
+  margin-left: 0.5rem;
+  display: inline-block;
+  min-width: 32px;
   text-align: center;
+}
+
+/* Rank prestige styles */
+.rank-e {
+  background: var(--background-alt);
+}
+
+.rank-d {
+  background: linear-gradient(45deg, #2d2d2d, #3a3a3a);
+}
+
+.rank-c {
+  background: linear-gradient(45deg, #374151, #4b5563);
+  color: #fff;
+}
+
+.rank-b {
+  background: linear-gradient(45deg, #1e3a8a, #2563eb);
+  color: #fff;
+  box-shadow: 0 0 5px rgba(37, 99, 235, 0.5);
+}
+
+.rank-a {
+  background: linear-gradient(45deg, #7c3aed, #c084fc);
+  color: #fff;
+  box-shadow: 0 0 8px rgba(124, 58, 237, 0.6);
+}
+
+.rank-s {
+  background: linear-gradient(45deg, #f59e0b, #fbbf24);
+  color: #fff;
+  box-shadow: 0 0 10px rgba(251, 191, 36, 0.7);
+}
+
+.rank-ss {
+  background: linear-gradient(45deg, #ec4899, #f472b6);
+  color: #fff;
+  box-shadow: 0 0 12px rgba(236, 72, 153, 0.8);
+}
+
+.rank-sss {
+  background: linear-gradient(45deg, #d97706, #facc15, #ef4444);
+  color: #fff;
+  box-shadow: 0 0 15px rgba(239, 68, 68, 0.9), 0 0 25px rgba(250, 204, 21, 0.9);
+  animation: premiumGlow 2s ease-in-out infinite alternate;
+}
+
+@keyframes premiumGlow {
+  from {
+    box-shadow: 0 0 10px rgba(250, 204, 21, 0.8), 0 0 20px rgba(239, 68, 68, 0.8);
+  }
+  to {
+    box-shadow: 0 0 20px rgba(250, 204, 21, 1), 0 0 30px rgba(239, 68, 68, 1);
+  }
 }
 
 .projects-stats {

--- a/xp.js
+++ b/xp.js
@@ -1,10 +1,10 @@
-export function calculateFocusXP(minutes, mandatorySessions) {
+function calculateFocusXP(minutes, mandatorySessions) {
   const baseXP = minutes / 18;
   const isBonus = mandatorySessions >= 2;
   return Math.round(baseXP * (isBonus ? 2 : 1));
 }
 
-export function calculateIntensityRate(weeklyScores) {
+function calculateIntensityRate(weeklyScores) {
   if (!weeklyScores || weeklyScores.length === 0) return 0;
   const recent = weeklyScores.slice(-4);
   const average =
@@ -12,7 +12,13 @@ export function calculateIntensityRate(weeklyScores) {
   return Math.round(average);
 }
 
-export function getIntensityLabel(rate, intensityLevels) {
+function getIntensityLabel(rate, intensityLevels) {
   const level = intensityLevels.find((l) => rate >= l.min && rate <= l.max);
   return level ? level.label : 'Errant du Néant';
 }
+
+module.exports = {
+  calculateFocusXP,
+  calculateIntensityRate,
+  getIntensityLabel
+};

--- a/xp.test.js
+++ b/xp.test.js
@@ -1,4 +1,4 @@
-import { calculateFocusXP, calculateIntensityRate } from './xp.js';
+const { calculateFocusXP, calculateIntensityRate } = require('./xp.js');
 
 test('calculateFocusXP returns bonus XP after mandatory sessions', () => {
   expect(calculateFocusXP(36, 2)).toBe(4); // 36 min -> baseXP=2, double=4


### PR DESCRIPTION
## Summary
- add UI refresh and save after weekly review XP gain
- convert XP utilities and tests to CommonJS
- display rank letters in progression view
- style ranks with prestige-based animations
- update Jest config for CommonJS

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687eec5e40248332b7daa4ace5a66ab8