### PR TITLE
Add Spotify integration with OAuth and playback controls

### DIFF
--- a/index.html
+++ b/index.html
@@ -370,9 +370,7 @@
                     <label class="futuristic-toggle">
                       <input type="checkbox" id="spotifyMode" />
                       <span class="toggle-slider"></span>
-                      <span class="toggle-label"
-                        >Mode Spotify (simulation)</span
-                      >
+                      <span class="toggle-label">Mode Spotify</span>
                     </label>
                   </div>
                 </div>

--- a/main.js
+++ b/main.js
@@ -3,8 +3,8 @@ const path = require('path');
 const fs = require('fs');
 const { google } = require('googleapis');
 
-const SPOTIFY_CLIENT_ID = 'xxxx';
-const SPOTIFY_CLIENT_SECRET = process.env.SPOTIFY_CLIENT_SECRET || '';
+const SPOTIFY_CLIENT_ID = '23351c09e9314ed39a04c0cee74b30db';
+const SPOTIFY_CLIENT_SECRET = '8b7c9ad0c1c84a87b43bb46be26540bd';
 const SPOTIFY_REDIRECT_URI = 'http://127.0.0.1:8888/callback';
 const SPOTIFY_SCOPES = 'streaming user-read-playback-state user-modify-playback-state user-read-currently-playing';
 
@@ -164,6 +164,30 @@ async function pauseSpotify() {
   }
 }
 
+async function launchSpotifyApp() {
+  try {
+    if (process.platform === 'win32') {
+      const exePath = path.join(process.env.APPDATA || '', 'Spotify', 'Spotify.exe');
+      if (fs.existsSync(exePath)) {
+        await shell.openPath(exePath);
+        return true;
+      }
+      await shell.openExternal('ms-windows-store://pdp/?productid=9NCBCSZSJRSB');
+      return false;
+    }
+    await shell.openExternal('spotify:');
+    return true;
+  } catch (err) {
+    console.error('Launch Spotify app error', err);
+    try {
+      if (process.platform === 'win32') {
+        await shell.openExternal('ms-windows-store://pdp/?productid=9NCBCSZSJRSB');
+      }
+    } catch {}
+    return false;
+  }
+}
+
 function createWindow() {
   const win = new BrowserWindow({
     width: 1200,
@@ -283,6 +307,7 @@ ipcMain.handle('is-spotify-connected', () => isSpotifyConnected());
 ipcMain.handle('disconnect-spotify', () => disconnectSpotify());
 ipcMain.handle('play-spotify', playSpotify);
 ipcMain.handle('pause-spotify', pauseSpotify);
+ipcMain.handle('launch-spotify-app', launchSpotifyApp);
 ipcMain.handle('open-external', async (event, url) => {
   try {
     await shell.openExternal(url);

--- a/main.js
+++ b/main.js
@@ -166,16 +166,9 @@ async function pauseSpotify() {
 
 async function launchSpotifyApp() {
   try {
-    if (process.platform === 'win32') {
-      const exePath = path.join(process.env.APPDATA || '', 'Spotify', 'Spotify.exe');
-      if (fs.existsSync(exePath)) {
-        await shell.openPath(exePath);
-        return true;
-      }
-      await shell.openExternal('ms-windows-store://pdp/?productid=9NCBCSZSJRSB');
-      return false;
-    }
-    await shell.openExternal('spotify:');
+    // Open the playlist URI directly. If Spotify is not installed,
+    // Windows will automatically redirect to the Microsoft Store page.
+    await shell.openExternal('spotify:playlist:37i9dQZF1DXadOVCgGhS7j');
     return true;
   } catch (err) {
     console.error('Launch Spotify app error', err);

--- a/main.js
+++ b/main.js
@@ -3,13 +3,166 @@ const path = require('path');
 const fs = require('fs');
 const { google } = require('googleapis');
 
+const SPOTIFY_CLIENT_ID = 'xxxx';
+const SPOTIFY_CLIENT_SECRET = process.env.SPOTIFY_CLIENT_SECRET || '';
+const SPOTIFY_REDIRECT_URI = 'http://127.0.0.1:8888/callback';
+const SPOTIFY_SCOPES = 'streaming user-read-playback-state user-modify-playback-state user-read-currently-playing';
+
 const CLIENT_ID = '1018441761342-dnnsun9f031ua3n58svfliena8e0lbet.apps.googleusercontent.com';
 const CLIENT_SECRET = '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';
 const REDIRECT_URI = 'http://localhost';
 const SCOPES = ['https://www.googleapis.com/auth/calendar'];
 
+const SPOTIFY_TOKEN_PATH = path.join(app.getPath('userData'), 'spotify_token.json');
+
 const TOKEN_PATH = path.join(app.getPath('userData'), 'google_token.json');
 let oauth2Client;
+
+// Spotify OAuth helpers
+function getSpotifyToken() {
+  try {
+    return JSON.parse(fs.readFileSync(SPOTIFY_TOKEN_PATH, 'utf8'));
+  } catch {
+    return null;
+  }
+}
+
+function saveSpotifyToken(data) {
+  fs.writeFileSync(SPOTIFY_TOKEN_PATH, JSON.stringify(data));
+}
+
+async function refreshSpotifyToken(refreshToken) {
+  const params = new URLSearchParams({
+    grant_type: 'refresh_token',
+    refresh_token: refreshToken,
+    client_id: SPOTIFY_CLIENT_ID,
+    client_secret: SPOTIFY_CLIENT_SECRET
+  });
+  const res = await fetch('https://accounts.spotify.com/api/token', {
+    method: 'POST',
+    body: params
+  });
+  if (!res.ok) return null;
+  const data = await res.json();
+  const tokenData = {
+    ...data,
+    refresh_token: data.refresh_token || refreshToken,
+    expires_at: Date.now() + data.expires_in * 1000
+  };
+  saveSpotifyToken(tokenData);
+  return tokenData;
+}
+
+async function getSpotifyAccessToken() {
+  const tokenData = getSpotifyToken();
+  if (!tokenData) return null;
+  if (tokenData.expires_at && tokenData.expires_at < Date.now()) {
+    const refreshed = await refreshSpotifyToken(tokenData.refresh_token);
+    return refreshed ? refreshed.access_token : null;
+  }
+  return tokenData.access_token;
+}
+
+async function connectSpotify() {
+  if (getSpotifyToken()) return true;
+  const params = new URLSearchParams({
+    client_id: SPOTIFY_CLIENT_ID,
+    response_type: 'code',
+    redirect_uri: SPOTIFY_REDIRECT_URI,
+    scope: SPOTIFY_SCOPES
+  });
+  const authUrl = `https://accounts.spotify.com/authorize?${params.toString()}`;
+  const authWin = new BrowserWindow({ width: 500, height: 600, show: true });
+  authWin.loadURL(authUrl);
+  return new Promise(resolve => {
+    const { session } = authWin.webContents;
+    const filter = { urls: [`${SPOTIFY_REDIRECT_URI}*`] };
+    session.webRequest.onBeforeRequest(filter, async details => {
+      const url = new URL(details.url);
+      const code = url.searchParams.get('code');
+      if (code) {
+        try {
+          const body = new URLSearchParams({
+            grant_type: 'authorization_code',
+            code,
+            redirect_uri: SPOTIFY_REDIRECT_URI,
+            client_id: SPOTIFY_CLIENT_ID,
+            client_secret: SPOTIFY_CLIENT_SECRET
+          });
+          const res = await fetch('https://accounts.spotify.com/api/token', {
+            method: 'POST',
+            body
+          });
+          const data = await res.json();
+          if (res.ok) {
+            data.expires_at = Date.now() + data.expires_in * 1000;
+            saveSpotifyToken(data);
+            resolve(true);
+          } else {
+            resolve(false);
+          }
+        } catch (err) {
+          console.error('Spotify auth error', err);
+          resolve(false);
+        } finally {
+          authWin.destroy();
+        }
+      }
+    });
+    authWin.on('closed', () => resolve(false));
+  });
+}
+
+function isSpotifyConnected() {
+  return !!getSpotifyToken();
+}
+
+function disconnectSpotify() {
+  try {
+    if (fs.existsSync(SPOTIFY_TOKEN_PATH)) {
+      fs.unlinkSync(SPOTIFY_TOKEN_PATH);
+    }
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function playSpotify() {
+  const access = await getSpotifyAccessToken();
+  if (!access) return false;
+  try {
+    const res = await fetch('https://api.spotify.com/v1/me/player/play', {
+      method: 'PUT',
+      headers: {
+        Authorization: `Bearer ${access}`,
+        'Content-Type': 'application/json'
+      },
+      body: JSON.stringify({
+        context_uri: 'spotify:playlist:37i9dQZF1DXadOVCgGhS7j'
+      })
+    });
+    return res.ok;
+  } catch (err) {
+    console.error('Spotify play error', err);
+    return false;
+  }
+}
+
+async function pauseSpotify() {
+  const access = await getSpotifyAccessToken();
+  if (!access) return false;
+  try {
+    const res = await fetch('https://api.spotify.com/v1/me/player/pause', {
+      method: 'PUT',
+      headers: { Authorization: `Bearer ${access}` }
+    });
+    return res.ok;
+  } catch (err) {
+    console.error('Spotify pause error', err);
+    return false;
+  }
+}
 
 function createWindow() {
   const win = new BrowserWindow({
@@ -125,6 +278,11 @@ ipcMain.handle('disconnect-google-calendar', () => {
     return false;
   }
 });
+ipcMain.handle('connect-spotify', connectSpotify);
+ipcMain.handle('is-spotify-connected', () => isSpotifyConnected());
+ipcMain.handle('disconnect-spotify', () => disconnectSpotify());
+ipcMain.handle('play-spotify', playSpotify);
+ipcMain.handle('pause-spotify', pauseSpotify);
 ipcMain.handle('open-external', async (event, url) => {
   try {
     await shell.openExternal(url);

--- a/preload.js
+++ b/preload.js
@@ -5,5 +5,10 @@ contextBridge.exposeInMainWorld('electronAPI', {
   logFocusSession: session => ipcRenderer.invoke('log-focus-session', session),
   isGoogleConnected: () => ipcRenderer.invoke('is-google-connected'),
   disconnectGoogleCalendar: () => ipcRenderer.invoke('disconnect-google-calendar'),
-  openExternal: url => ipcRenderer.invoke('open-external', url)
+  openExternal: url => ipcRenderer.invoke('open-external', url),
+  connectSpotify: () => ipcRenderer.invoke('connect-spotify'),
+  isSpotifyConnected: () => ipcRenderer.invoke('is-spotify-connected'),
+  disconnectSpotify: () => ipcRenderer.invoke('disconnect-spotify'),
+  playSpotify: () => ipcRenderer.invoke('play-spotify'),
+  pauseSpotify: () => ipcRenderer.invoke('pause-spotify')
 });

--- a/preload.js
+++ b/preload.js
@@ -10,5 +10,6 @@ contextBridge.exposeInMainWorld('electronAPI', {
   isSpotifyConnected: () => ipcRenderer.invoke('is-spotify-connected'),
   disconnectSpotify: () => ipcRenderer.invoke('disconnect-spotify'),
   playSpotify: () => ipcRenderer.invoke('play-spotify'),
-  pauseSpotify: () => ipcRenderer.invoke('pause-spotify')
+  pauseSpotify: () => ipcRenderer.invoke('pause-spotify'),
+  launchSpotifyApp: () => ipcRenderer.invoke('launch-spotify-app')
 });

--- a/script.js
+++ b/script.js
@@ -355,8 +355,13 @@ class MyRPGLifeApp {
     this.disableTimerOptions();
 
     const spotifyBox = document.getElementById('spotifyMode');
-    if (spotifyBox?.checked && window.electronAPI?.playSpotify) {
-      window.electronAPI.playSpotify();
+    if (spotifyBox?.checked && window.electronAPI) {
+      if (window.electronAPI.launchSpotifyApp) {
+        window.electronAPI.launchSpotifyApp();
+      }
+      if (window.electronAPI.playSpotify) {
+        window.electronAPI.playSpotify();
+      }
     }
     
     const startPauseBtn = document.getElementById('startPauseBtn');

--- a/script.js
+++ b/script.js
@@ -16,7 +16,8 @@ class MyRPGLifeApp {
       breakRemaining: 0,
       breakCount: 0,
       totalBreaks: 0,
-      autoBreaks: false
+      autoBreaks: false,
+      spotifyModeActive: false
     };
 
     // Project editing state
@@ -355,7 +356,8 @@ class MyRPGLifeApp {
     this.disableTimerOptions();
 
     const spotifyBox = document.getElementById('spotifyMode');
-    if (spotifyBox?.checked && window.electronAPI) {
+    this.timerState.spotifyModeActive = !!spotifyBox?.checked;
+    if (this.timerState.spotifyModeActive && window.electronAPI) {
       if (window.electronAPI.launchSpotifyApp) {
         window.electronAPI.launchSpotifyApp();
       }
@@ -425,8 +427,7 @@ class MyRPGLifeApp {
         this.updateDashboard();
       }
     }
-    const spotifyBox = document.getElementById('spotifyMode');
-    if (spotifyBox?.checked && window.electronAPI?.pauseSpotify) {
+    if (this.timerState.spotifyModeActive && window.electronAPI?.pauseSpotify) {
       window.electronAPI.pauseSpotify();
     }
     this.resetTimer();
@@ -440,6 +441,7 @@ class MyRPGLifeApp {
     this.timerState.isBreak = false;
     this.timerState.breakRemaining = 0;
     this.timerState.breakCount = 0;
+    this.timerState.spotifyModeActive = false;
 
     this.exitFocusMode();
     this.enableTimerOptions();
@@ -479,8 +481,7 @@ class MyRPGLifeApp {
     this.updateFocusStats();
     this.updateDashboard();
 
-    const spotifyBox = document.getElementById('spotifyMode');
-    if (spotifyBox?.checked && window.electronAPI?.pauseSpotify) {
+    if (this.timerState.spotifyModeActive && window.electronAPI?.pauseSpotify) {
       window.electronAPI.pauseSpotify();
     }
 

--- a/script.js
+++ b/script.js
@@ -353,6 +353,11 @@ class MyRPGLifeApp {
 
     this.enterFocusMode();
     this.disableTimerOptions();
+
+    const spotifyBox = document.getElementById('spotifyMode');
+    if (spotifyBox?.checked && window.electronAPI?.playSpotify) {
+      window.electronAPI.playSpotify();
+    }
     
     const startPauseBtn = document.getElementById('startPauseBtn');
     const startPauseText = document.getElementById('startPauseText');
@@ -415,6 +420,10 @@ class MyRPGLifeApp {
         this.updateDashboard();
       }
     }
+    const spotifyBox = document.getElementById('spotifyMode');
+    if (spotifyBox?.checked && window.electronAPI?.pauseSpotify) {
+      window.electronAPI.pauseSpotify();
+    }
     this.resetTimer();
   }
 
@@ -464,6 +473,11 @@ class MyRPGLifeApp {
 
     this.updateFocusStats();
     this.updateDashboard();
+
+    const spotifyBox = document.getElementById('spotifyMode');
+    if (spotifyBox?.checked && window.electronAPI?.pauseSpotify) {
+      window.electronAPI.pauseSpotify();
+    }
 
     this.showNotification(`🎯 Session terminée ! +${xpGained} XP`, 'success');
     this.resetTimer();
@@ -1287,6 +1301,9 @@ class MyRPGLifeApp {
     const googleConnected = window.electronAPI?.isGoogleConnected
       ? await window.electronAPI.isGoogleConnected()
       : false;
+    const spotifyConnected = window.electronAPI?.isSpotifyConnected
+      ? await window.electronAPI.isSpotifyConnected()
+      : false;
 
     settingsContent.innerHTML = `
       <div class="settings-grid">
@@ -1453,7 +1470,21 @@ class MyRPGLifeApp {
               : `<button id="connectGoogleCalendarBtn" class="data-btn connect-btn">Se connecter à Google Calendar</button>`}
           </div>
         </div>
-        
+        <div class="settings-card spotify-settings">
+          <div class="settings-header">
+            <div class="settings-icon">🎵</div>
+            <h3>Spotify</h3>
+          </div>
+          <div class="settings-content">
+            ${spotifyConnected
+              ? `<div class="connected-status"><span class="status-icon">🟢</span> Compte Spotify connecté</div>
+                 <div class="gc-actions">
+                   <button id="disconnectSpotifyBtn" class="data-btn disconnect-btn">Se déconnecter</button>
+                 </div>`
+              : `<button id="connectSpotifyBtn" class="data-btn connect-btn">Se connecter à Spotify</button>`}
+          </div>
+        </div>
+
         <!-- Informations -->
         <div class="settings-card info-settings">
           <div class="settings-header">
@@ -2158,6 +2189,30 @@ class MyRPGLifeApp {
           this.renderSettings();
         } else {
           this.showNotification('Erreur de déconnexion Google', 'error');
+        }
+      });
+    }
+
+    const connectSpotifyBtn = document.getElementById('connectSpotifyBtn');
+    if (connectSpotifyBtn && window.electronAPI) {
+      connectSpotifyBtn.addEventListener('click', async () => {
+        const ok = await window.electronAPI.connectSpotify();
+        if (ok) {
+          this.showNotification('Spotify connecté', 'success');
+          this.renderSettings();
+        } else {
+          this.showNotification('Erreur de connexion Spotify', 'error');
+        }
+      });
+    }
+
+    const disconnectSpotifyBtn = document.getElementById('disconnectSpotifyBtn');
+    if (disconnectSpotifyBtn && window.electronAPI) {
+      disconnectSpotifyBtn.addEventListener('click', async () => {
+        const ok = await window.electronAPI.disconnectSpotify();
+        if (ok) {
+          this.showNotification('Spotify déconnecté', 'success');
+          this.renderSettings();
         }
       });
     }


### PR DESCRIPTION
## Summary
- update toggle text for Spotify mode
- expose Spotify IPC methods in preload
- implement Spotify OAuth and playback helpers in main process
- render Spotify connection settings and handle user actions
- control Spotify playback when focus timer starts or ends

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6880041e15c88332bb8dd2193618d7d3