### PR TITLE
Ensure immediate data saving after log actions

### DIFF
--- a/script.js
+++ b/script.js
@@ -197,6 +197,7 @@ class MyRPGLifeApp {
     } else {
       this.showNotification('Sport déjà enregistré aujourd\'hui', 'info');
     }
+    this.saveData();
   }
 
   showSleepModal() {
@@ -278,6 +279,7 @@ class MyRPGLifeApp {
       this.showNotification('Sommeil déjà enregistré aujourd\'hui', 'info');
       this.closeModal();
     }
+    this.saveData();
   }
 
   showDistractionModal() {
@@ -341,6 +343,7 @@ class MyRPGLifeApp {
     this.showNotification(message, 'error');
     this.closeModal();
     this.updateUI();
+    this.saveData();
   }
 
   // Timer functions
@@ -2673,6 +2676,7 @@ class MyRPGLifeApp {
     this.addXP(5, 'Coffre Mystique - Récompense Sûre');
     this.showNotification('✨ +5 XP de récompense sûre !', 'success');
     this.hideDoubleOrNothingChest();
+    this.saveData();
   }
 
   chooseDoubleOrNothing() {
@@ -2685,6 +2689,7 @@ class MyRPGLifeApp {
     // Set up tomorrow's challenge
     this.data.doubleOrNothingActive = true;
     this.showNotification('🔥 Défi accepté ! Bonne chance demain !', 'warning');
+    this.saveData();
   }
 
   showStartOverlay() {


### PR DESCRIPTION
## Summary
- save progress immediately when logging sport, sleep, and distractions
- save progress after claiming or starting double or nothing challenges

## Testing
- `npm test`
- `npm run lint` *(fails: Cannot use import statement outside a module)*

------
https://chatgpt.com/codex/tasks/task_e_68813e42440c83329b2a932b185d5e0c