### PR TITLE
Add validation for saved data format

### DIFF
--- a/index.html
+++ b/index.html
@@ -620,6 +620,7 @@
     <!-- Notifications -->
     <div class="notifications-container" id="notifications"></div>
 
+    <script src="validation.js"></script>
     <script src="script.js"></script>
   </body>
 </html>

--- a/script.js
+++ b/script.js
@@ -2304,11 +2304,7 @@ class MyRPGLifeApp {
         reader.onload = (e) => {
           try {
             const importedData = JSON.parse(e.target.result);
-            const requiredFields = ['totalXP', 'projects', 'focusSessions'];
-            const isValid =
-              importedData && requiredFields.every((f) => f in importedData);
-
-            if (!isValid) {
+            if (!validateData(importedData)) {
               throw new Error('Invalid data format');
             }
 
@@ -2617,23 +2613,27 @@ class MyRPGLifeApp {
     };
   }
 
+
   loadData() {
     const defaultData = this.getDefaultData();
-    
+
     try {
       const saved = localStorage.getItem('myRPGLifeData');
       if (saved) {
         const parsed = JSON.parse(saved);
-        const data = {
-          ...defaultData,
-          ...parsed,
-          settings: { ...defaultData.settings, ...(parsed.settings || {}) },
-          lastDailyReset: parsed.lastDailyReset || defaultData.lastDailyReset
-        };
-        if (parsed.started === undefined) {
-          data.started = (parsed.totalXP > 0) || (parsed.seasonHistory && parsed.seasonHistory.length > 0);
+        if (validateData(parsed)) {
+          const data = {
+            ...defaultData,
+            ...parsed,
+            settings: { ...defaultData.settings, ...(parsed.settings || {}) },
+            lastDailyReset: parsed.lastDailyReset || defaultData.lastDailyReset
+          };
+          if (parsed.started === undefined) {
+            data.started = (parsed.totalXP > 0) || (parsed.seasonHistory && parsed.seasonHistory.length > 0);
+          }
+          return data;
         }
-        return data;
+        console.warn('Invalid saved data format, using defaults.');
       }
       return defaultData;
     } catch (error) {

--- a/validation.js
+++ b/validation.js
@@ -1,0 +1,22 @@
+function validateData(data) {
+  if (!data || typeof data !== 'object') return false;
+  const arrayFields = [
+    'projects',
+    'focusSessions',
+    'xpHistory',
+    'seasonHistory',
+    'weeklyReviews',
+    'achievements'
+  ];
+  if (arrayFields.some((field) => !Array.isArray(data[field]))) {
+    return false;
+  }
+  if (typeof data.totalXP !== 'number') return false;
+  return true;
+}
+
+if (typeof module !== 'undefined' && module.exports) {
+  module.exports = { validateData };
+} else {
+  window.validateData = validateData;
+}


### PR DESCRIPTION
## Summary
- add a reusable `validation.js` helper
- verify imported and saved data with `validateData`
- warn when saved data is malformed
- include new helper script in `index.html`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68814bb11b2483328bf39948bd50371e