### PR TITLE
Add data versioning with migrations

### DIFF
--- a/validation.js
+++ b/validation.js
@@ -12,6 +12,7 @@ function validateData(data) {
     return false;
   }
   if (typeof data.totalXP !== 'number') return false;
+  if (data.version !== undefined && typeof data.version !== 'number') return false;
   return true;
 }
 


### PR DESCRIPTION
## Summary
- add `CURRENT_DATA_VERSION` constant
- attach a `version` field to stored data
- add `migrateData` method and migrate during `loadData`
- ensure `saveData` always writes the current version
- validate optional `version` field

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6881536ca7c883329cbd8a9fcf7b0355