### PR TITLE
Add detailed intensity levels

### DIFF
--- a/index.html
+++ b/index.html
@@ -120,12 +120,12 @@
             </div>
 
             <!-- Taux d'Intensité -->
-            <div class="intensity-card">
+            <div class="intensity-card" id="intensityCard">
               <h3>Taux d'Intensité</h3>
               <div class="intensity-display">
                 <div class="intensity-value" id="intensityValue">0%</div>
                 <div class="intensity-label" id="intensityLabel">
-                  Errant du Néant
+                  👤 Errant du Néant
                 </div>
               </div>
               <div class="intensity-bar">

--- a/index.html
+++ b/index.html
@@ -142,7 +142,7 @@
                   <span class="challenge-label">Objectif quotidien</span>
                 </div>
                 <div class="challenge-progress">
-                  <div class="challenge-bar">
+                  <div class="challenge-bar" id="challengeBar">
                     <div class="challenge-fill" id="challengeFill"></div>
                   </div>
                   <span class="challenge-status" id="challengeStatus"

--- a/script.js
+++ b/script.js
@@ -2189,10 +2189,11 @@ class MyRPGLifeApp {
       const base = extractBaseColor(l.color);
       const glow = lightenColor(base, 30);
       return `
-        <div class="intensity-level" style="--level-bg:${l.color};--level-glow:${glow}">
+        <div class="intensity-level" style="--level-color:${base};--level-glow:${glow}">
+          <div class="level-icon">${l.emoji}</div>
           <div class="level-info">
-            <div class="level-title">${l.emoji} ${l.title} (${l.min}-${l.max}%)</div>
-            <div class="level-role">Rôle : ${l.role}</div>
+            <div class="level-title">${l.title} (${l.min}-${l.max}%)</div>
+            <div class="level-role">${l.role}</div>
             <div class="level-desc">${l.description}</div>
           </div>
         </div>
@@ -2504,11 +2505,15 @@ class MyRPGLifeApp {
     // Update challenge progress
     const challengeFill = document.getElementById('challengeFill');
     const challengeStatus = document.getElementById('challengeStatus');
+    const challengeBar = document.getElementById('challengeBar');
     
     if (challengeFill && challengeStatus) {
       const progress = Math.min(100, (this.data.dailyXP / 15) * 100);
       challengeFill.style.width = `${progress}%`;
       challengeStatus.textContent = `${this.data.dailyXP}/15 XP`;
+      if (challengeBar) {
+        challengeBar.style.setProperty('--progress', `${progress}%`);
+      }
     }
 
     // Update season goal progress

--- a/script.js
+++ b/script.js
@@ -60,9 +60,29 @@ const INTENSITY_LEVELS = [
     role: 'Maître',
     description:
       "Tu exploses tous tes objectifs. Tu es en pleine fusion avec ta mission. Rien ne peut t\u2019arrêter : tu es aligné, focus, inarrêtable.",
-    color: 'linear-gradient(#8a2387,#e94057,#f27121)'
+    color: 'linear-gradient(#8a2387,#e94057,#f27121,#fffb00)'
   }
 ];
+
+function extractBaseColor(color) {
+  if (color.startsWith('linear-gradient')) {
+    const match = color.match(/#(?:[0-9a-fA-F]{3,6})/);
+    return match ? match[0] : '#ffffff';
+  }
+  return color;
+}
+
+function lightenColor(hex, percent) {
+  let num = parseInt(hex.replace('#', ''), 16);
+  const amt = Math.round(2.55 * percent);
+  const r = (num >> 16) + amt;
+  const g = ((num >> 8) & 0x00ff) + amt;
+  const b = (num & 0x00ff) + amt;
+  const clamp = v => Math.max(0, Math.min(255, v));
+  return (
+    '#' + ((1 << 24) + (clamp(r) << 16) + (clamp(g) << 8) + clamp(b)).toString(16).slice(1)
+  );
+}
 
 class MyRPGLifeApp {
     constructor() {
@@ -2919,12 +2939,21 @@ class MyRPGLifeApp {
     if (!valueEl || !labelEl || !fillEl) return;
 
     const level = INTENSITY_LEVELS.find(l => rate >= l.min && rate <= l.max) || INTENSITY_LEVELS[0];
+    const card = document.getElementById('intensityCard');
+
     valueEl.textContent = `${rate}%`;
     labelEl.textContent = `${level.emoji} ${level.title}`;
     fillEl.style.width = `${Math.min(rate, 100)}%`;
     fillEl.style.background = level.color;
-    valueEl.style.color = level.color.includes('gradient') ? '#ffff66' : level.color;
-    if (rate >= 95) {
+    fillEl.classList.add('bar-shimmer');
+
+    const base = extractBaseColor(level.color);
+    const light = lightenColor(base, 30);
+    card.style.setProperty('--intensity-color', base);
+    fillEl.style.boxShadow = `0 0 10px ${light}`;
+    valueEl.style.color = base;
+
+    if (rate >= 85) {
       valueEl.classList.add('intensity-glow');
     } else {
       valueEl.classList.remove('intensity-glow');

--- a/script.js
+++ b/script.js
@@ -1,5 +1,69 @@
 const CURRENT_DATA_VERSION = 1;
 
+// Intensity levels used to display the progress bar and labels
+const INTENSITY_LEVELS = [
+  {
+    min: 0,
+    max: 39,
+    emoji: '👤',
+    title: 'Errant du Néant',
+    role: 'Déserteur',
+    description:
+      "Tu n\u2019es pas encore dans le Game. Tu fuis tes missions, tu manques de régularité et d\u2019effort soutenu. Rien n\u2019est encore vraiment enclenché.",
+    color: 'linear-gradient(#666,#000)'
+  },
+  {
+    min: 40,
+    max: 59,
+    emoji: '⚖️',
+    title: 'Survivant',
+    role: 'Inconstant',
+    description:
+      "Tu fais le strict minimum. Tu es plus dans la réaction que dans l\u2019action. Tu avances à petits pas, mais sans vraie direction ou maîtrise.",
+    color: '#16a34a'
+  },
+  {
+    min: 60,
+    max: 74,
+    emoji: '🔥',
+    title: 'Forgeron de Volonté',
+    role: 'Bâtisseur Stable',
+    description:
+      "Tu commences à structurer, à créer une base solide. Tu avances, tu construis, mais tu t\u2019arrêtes parfois en chemin. Il manque encore de la régularité.",
+    color: '#f97316'
+  },
+  {
+    min: 75,
+    max: 84,
+    emoji: '💎',
+    title: 'Artisan du Focus',
+    role: 'Fort & cohérent',
+    description:
+      "Tu produis régulièrement, tu tiens tes engagements. Tu gagnes du terrain, tu consolides ton système. La constance commence à porter ses fruits.",
+    color: 'linear-gradient(#0911b0,#7408c7)'
+  },
+  {
+    min: 85,
+    max: 94,
+    emoji: '⚔️',
+    title: 'Champion du Flow',
+    role: 'Leader Ultra discipliné',
+    description:
+      "Tu incarnes la discipline et la constance. Tu avances avec puissance, tu es fiable et tu inspires ceux qui t\u2019observent. Ton momentum est fort.",
+    color: '#dc2626'
+  },
+  {
+    min: 95,
+    max: 100,
+    emoji: '🌌',
+    title: 'Transcendant',
+    role: 'Maître',
+    description:
+      "Tu exploses tous tes objectifs. Tu es en pleine fusion avec ta mission. Rien ne peut t\u2019arrêter : tu es aligné, focus, inarrêtable.",
+    color: 'linear-gradient(#8a2387,#e94057,#f27121)'
+  }
+];
+
 class MyRPGLifeApp {
     constructor() {
     this.data = this.loadData();
@@ -66,6 +130,11 @@ class MyRPGLifeApp {
     const rankCard = document.getElementById('rankCard');
     if (rankCard) {
       rankCard.addEventListener('click', () => this.showRanksModal());
+    }
+
+    const intensityCard = document.querySelector('.intensity-card');
+    if (intensityCard) {
+      intensityCard.addEventListener('click', () => this.showIntensityModal());
     }
 
     // Bouton focus principal
@@ -2095,6 +2164,30 @@ class MyRPGLifeApp {
     this.showModal(modalContent, true);
   }
 
+  showIntensityModal() {
+    const levelsHtml = INTENSITY_LEVELS.map(l => `
+      <div class="intensity-level">
+        <span class="level-color" style="background:${l.color}"></span>
+        <div class="level-info">
+          <div class="level-title">${l.emoji} ${l.title} (${l.min}-${l.max}%)</div>
+          <div class="level-role">Rôle : ${l.role}</div>
+          <div class="level-desc">${l.description}</div>
+        </div>
+      </div>
+    `).join('');
+
+    const modalContent = `
+      <div class="modal-header">
+        <h3>Niveaux d'Intensité</h3>
+        <button class="modal-close" onclick="app.closeModal()">×</button>
+      </div>
+      <div class="modal-body intensity-modal">
+        ${levelsHtml}
+      </div>
+    `;
+    this.showModal(modalContent, true);
+  }
+
   renderRankProgressBar() {
     const ranks = [
       { name: 'Paumé improductif', xp: 0 },
@@ -2424,6 +2517,8 @@ class MyRPGLifeApp {
       const label = ranks[this.data.seasonGoalXP || 600] || "Sentinelle de l'Ascension (S)";
       seasonLabel.innerHTML = `Atteindre le rang <strong>${label}</strong>`;
     }
+
+    this.updateIntensityDisplay();
 
     this.updateSeasonDisplay();
     this.updateLastSeasonDisplay();
@@ -2812,6 +2907,27 @@ class MyRPGLifeApp {
       const percent = Math.min(100, (diffDays / 42) * 100);
       seasonFill.style.width = `${percent}%`;
       seasonFill.classList.toggle('ending', remaining <= 7);
+    }
+  }
+
+  updateIntensityDisplay() {
+    const rate = this.calculateIntensityRate();
+    const valueEl = document.getElementById('intensityValue');
+    const labelEl = document.getElementById('intensityLabel');
+    const fillEl = document.getElementById('intensityFill');
+
+    if (!valueEl || !labelEl || !fillEl) return;
+
+    const level = INTENSITY_LEVELS.find(l => rate >= l.min && rate <= l.max) || INTENSITY_LEVELS[0];
+    valueEl.textContent = `${rate}%`;
+    labelEl.textContent = `${level.emoji} ${level.title}`;
+    fillEl.style.width = `${Math.min(rate, 100)}%`;
+    fillEl.style.background = level.color;
+    valueEl.style.color = level.color.includes('gradient') ? '#ffff66' : level.color;
+    if (rate >= 95) {
+      valueEl.classList.add('intensity-glow');
+    } else {
+      valueEl.classList.remove('intensity-glow');
     }
   }
 

--- a/script.js
+++ b/script.js
@@ -2185,16 +2185,19 @@ class MyRPGLifeApp {
   }
 
   showIntensityModal() {
-    const levelsHtml = INTENSITY_LEVELS.map(l => `
-      <div class="intensity-level">
-        <span class="level-color" style="background:${l.color}"></span>
-        <div class="level-info">
-          <div class="level-title">${l.emoji} ${l.title} (${l.min}-${l.max}%)</div>
-          <div class="level-role">Rôle : ${l.role}</div>
-          <div class="level-desc">${l.description}</div>
+    const levelsHtml = INTENSITY_LEVELS.map(l => {
+      const base = extractBaseColor(l.color);
+      const glow = lightenColor(base, 30);
+      return `
+        <div class="intensity-level" style="--level-bg:${l.color};--level-glow:${glow}">
+          <div class="level-info">
+            <div class="level-title">${l.emoji} ${l.title} (${l.min}-${l.max}%)</div>
+            <div class="level-role">Rôle : ${l.role}</div>
+            <div class="level-desc">${l.description}</div>
+          </div>
         </div>
-      </div>
-    `).join('');
+      `;
+    }).join('');
 
     const modalContent = `
       <div class="modal-header">
@@ -2951,6 +2954,7 @@ class MyRPGLifeApp {
     const light = lightenColor(base, 30);
     card.style.setProperty('--intensity-color', base);
     fillEl.style.boxShadow = `0 0 10px ${light}`;
+    card.style.boxShadow = `0 0 15px ${light}`;
     valueEl.style.color = base;
 
     if (rate >= 85) {

--- a/styles.css
+++ b/styles.css
@@ -208,8 +208,8 @@ body {
   position: absolute;
   inset: 0;
   background: linear-gradient(120deg, transparent 0%, rgba(255, 255, 255, 0.08) 50%, transparent 100%);
-  transform: translateX(-100%);
-  animation: cardShimmer 6s linear infinite;
+  background-size: 200% 100%;
+  animation: cardShimmerMove 6s linear infinite;
 }
 
 /* Rang et Avatar */
@@ -446,17 +446,15 @@ body {
 .challenge-fill::after {
   content: '';
   position: absolute;
-  top: 0;
-  left: 0;
-  right: 0;
-  bottom: 0;
+  inset: 0;
   background: linear-gradient(90deg, transparent 0%, rgba(255, 255, 255, 0.3) 50%, transparent 100%);
-  animation: shimmer 2s infinite;
+  background-size: 200% 100%;
+  animation: challengeShimmer 3s linear infinite;
 }
 
-@keyframes shimmer {
-  0% { transform: translateX(-100%); }
-  100% { transform: translateX(100%); }
+@keyframes challengeShimmer {
+  0% { background-position: -200% 0; }
+  100% { background-position: 200% 0; }
 }
 
 .challenge-status {
@@ -778,9 +776,9 @@ body {
   100% { background-position: -200% 0; }
 }
 
-@keyframes cardShimmer {
-  0% { transform: translateX(-100%); }
-  100% { transform: translateX(100%); }
+@keyframes cardShimmerMove {
+  0% { background-position: -200% 0; }
+  100% { background-position: 200% 0; }
 }
 
 /* Carte de la saison pr\E9c\E9dente */
@@ -3662,19 +3660,19 @@ select:focus {
 }
 
 .intensity-level {
-  background: rgba(0, 0, 0, 0.4);
+  background: var(--level-bg, rgba(0, 0, 0, 0.4));
   padding: 0.75rem 1rem;
   border-radius: 8px;
   display: flex;
-  align-items: flex-start;
-  gap: 0.75rem;
+  flex-direction: column;
+  gap: 0.5rem;
+  color: #fff;
+  box-shadow: 0 0 10px var(--level-glow, rgba(255,255,255,0.2));
+  border: 1px solid var(--level-glow, transparent);
 }
 
 .level-color {
-  width: 30px;
-  height: 14px;
-  border-radius: 4px;
-  box-shadow: 0 0 6px rgba(255,255,255,0.3);
+  display: none;
 }
 
 .level-info {

--- a/styles.css
+++ b/styles.css
@@ -431,6 +431,8 @@ body {
   margin-bottom: 1rem;
   border: 1px solid rgba(255, 255, 255, 0.1);
   box-shadow: inset 0 2px 4px rgba(0, 0, 0, 0.2);
+  position: relative;
+  --progress: 0%;
 }
 
 .challenge-fill {
@@ -443,13 +445,17 @@ body {
   box-shadow: 0 0 15px rgba(16, 185, 129, 0.4);
 }
 
-.challenge-fill::after {
+.challenge-bar::after {
   content: '';
   position: absolute;
-  inset: 0;
+  top: 0;
+  bottom: 0;
+  left: var(--progress, 0%);
+  width: calc(100% - var(--progress, 0%));
   background: linear-gradient(90deg, transparent 0%, rgba(255, 255, 255, 0.3) 50%, transparent 100%);
   background-size: 200% 100%;
   animation: challengeShimmer 3s linear infinite;
+  pointer-events: none;
 }
 
 @keyframes challengeShimmer {
@@ -3660,19 +3666,34 @@ select:focus {
 }
 
 .intensity-level {
-  background: var(--level-bg, rgba(0, 0, 0, 0.4));
-  padding: 0.75rem 1rem;
-  border-radius: 8px;
+  position: relative;
   display: flex;
-  flex-direction: column;
-  gap: 0.5rem;
+  align-items: flex-start;
+  gap: 0.75rem;
+  background: var(--card-bg);
+  border-radius: 8px;
+  border: 1px solid var(--border-color);
+  padding: 1rem;
   color: #fff;
-  box-shadow: 0 0 10px var(--level-glow, rgba(255,255,255,0.2));
-  border: 1px solid var(--level-glow, transparent);
+  box-shadow: 0 0 10px var(--level-glow, rgba(255,255,255,0.15));
 }
 
-.level-color {
-  display: none;
+.intensity-level::before {
+  content: '';
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  left: 0;
+  width: 6px;
+  background: var(--level-color, var(--accent-color));
+  border-radius: 8px 0 0 8px;
+}
+
+
+.level-icon {
+  font-size: 1.4rem;
+  flex-shrink: 0;
+  margin-top: 2px;
 }
 
 .level-info {
@@ -3682,12 +3703,19 @@ select:focus {
 
 
 .level-title {
-  font-weight: bold;
+  font-weight: 700;
+  font-size: 1rem;
+}
+
+.level-role {
+  color: var(--level-color, var(--accent-color));
+  font-weight: 600;
+  font-size: 0.9rem;
 }
 
 .level-desc {
   font-size: 0.85rem;
-  opacity: 0.85;
+  opacity: 0.8;
 }
 
 @keyframes intensityGlow {

--- a/styles.css
+++ b/styles.css
@@ -199,6 +199,17 @@ body {
 
 .intensity-card {
   cursor: pointer;
+  background: linear-gradient(135deg, #1e1e2e 0%, #151521 50%, #0c0c12 100%);
+  --intensity-color: var(--accent-color);
+}
+
+.intensity-card::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(120deg, transparent 0%, rgba(255, 255, 255, 0.08) 50%, transparent 100%);
+  transform: translateX(-100%);
+  animation: cardShimmer 6s linear infinite;
 }
 
 /* Rang et Avatar */
@@ -722,9 +733,11 @@ body {
 
 .intensity-value {
   font-size: 2.5rem;
-  font-weight: bold;
-  color: var(--accent-color);
+  font-weight: 900;
+  font-family: 'Orbitron', monospace;
   margin-bottom: 0.5rem;
+  color: var(--intensity-color, var(--accent-color));
+  text-shadow: 0 0 5px var(--intensity-color, var(--accent-color));
 }
 
 .intensity-label {
@@ -734,18 +747,40 @@ body {
 
 .intensity-bar {
   width: 100%;
-  height: 8px;
+  height: 10px;
   background: var(--accent-bg);
-  border-radius: 4px;
+  border-radius: 6px;
   overflow: hidden;
+  position: relative;
 }
 
 .intensity-fill {
   height: 100%;
   background: var(--gradient-secondary);
-  border-radius: 4px;
+  border-radius: 6px;
   transition: width 0.5s ease;
   width: 0%;
+  position: relative;
+  background-size: 200% auto;
+}
+
+.bar-shimmer::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(90deg, transparent 0%, rgba(255,255,255,0.4) 50%, transparent 100%);
+  background-size: 200% 100%;
+  animation: shimmerMove 4s linear infinite;
+}
+
+@keyframes shimmerMove {
+  0% { background-position: 200% 0; }
+  100% { background-position: -200% 0; }
+}
+
+@keyframes cardShimmer {
+  0% { transform: translateX(-100%); }
+  100% { transform: translateX(100%); }
 }
 
 /* Carte de la saison pr\E9c\E9dente */
@@ -3627,21 +3662,26 @@ select:focus {
 }
 
 .intensity-level {
+  background: rgba(0, 0, 0, 0.4);
+  padding: 0.75rem 1rem;
+  border-radius: 8px;
   display: flex;
   align-items: flex-start;
-  gap: 0.5rem;
+  gap: 0.75rem;
 }
 
 .level-color {
-  width: 24px;
-  height: 12px;
+  width: 30px;
+  height: 14px;
   border-radius: 4px;
+  box-shadow: 0 0 6px rgba(255,255,255,0.3);
 }
 
 .level-info {
   display: flex;
   flex-direction: column;
 }
+
 
 .level-title {
   font-weight: bold;
@@ -3654,10 +3694,10 @@ select:focus {
 
 @keyframes intensityGlow {
   0%, 100% {
-    text-shadow: 0 0 0 rgba(255, 255, 102, 0);
+    text-shadow: 0 0 5px var(--intensity-color, #ffff66);
   }
   50% {
-    text-shadow: 0 0 8px rgba(255, 255, 102, 1);
+    text-shadow: 0 0 15px var(--intensity-color, #ffff66);
   }
 }
 

--- a/styles.css
+++ b/styles.css
@@ -189,12 +189,16 @@ body {
   overflow: hidden;
 }
 
-.rank-card:hover, .xp-card:hover, .season-card:hover, 
-.intensity-card:hover, .daily-actions:hover, 
+.rank-card:hover, .xp-card:hover, .season-card:hover,
+.intensity-card:hover, .daily-actions:hover,
 .focus-cta:hover, .season-goal:hover, .streak-card:hover {
   transform: translateY(-5px);
   box-shadow: 0 10px 30px rgba(0, 212, 255, 0.1);
   border-color: var(--primary-color);
+}
+
+.intensity-card {
+  cursor: pointer;
 }
 
 /* Rang et Avatar */
@@ -3607,6 +3611,53 @@ select:focus {
   }
   to {
     transform: rotate(360deg);
+  }
+}
+
+.intensity-glow {
+  animation: intensityGlow 2s ease-in-out infinite;
+}
+
+.intensity-modal {
+  max-height: 60vh;
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.intensity-level {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.5rem;
+}
+
+.level-color {
+  width: 24px;
+  height: 12px;
+  border-radius: 4px;
+}
+
+.level-info {
+  display: flex;
+  flex-direction: column;
+}
+
+.level-title {
+  font-weight: bold;
+}
+
+.level-desc {
+  font-size: 0.85rem;
+  opacity: 0.85;
+}
+
+@keyframes intensityGlow {
+  0%, 100% {
+    text-shadow: 0 0 0 rgba(255, 255, 102, 0);
+  }
+  50% {
+    text-shadow: 0 0 8px rgba(255, 255, 102, 1);
   }
 }
 

--- a/xp.js
+++ b/xp.js
@@ -14,7 +14,7 @@ function calculateIntensityRate(weeklyScores) {
 
 function getIntensityLabel(rate, intensityLevels) {
   const level = intensityLevels.find((l) => rate >= l.min && rate <= l.max);
-  return level ? level.label : 'Errant du Néant';
+  return level ? `${level.emoji} ${level.title}` : 'Errant du Néant';
 }
 
 module.exports = {


### PR DESCRIPTION
## Summary
- enrich intensity level definitions with emoji, title, role and description
- show these details in the intensity level modal
- update gauge label formatting
- tweak styles for the modal layout

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68815f31cd848332b650807cb8045394