### PR TITLE
Implement circular intensity meter with slower shimmer

### DIFF
--- a/index.html
+++ b/index.html
@@ -123,13 +123,22 @@
             <div class="intensity-card" id="intensityCard">
               <h3>Taux d'Intensité</h3>
               <div class="intensity-display">
-                <div class="intensity-value" id="intensityValue">0%</div>
+                <div class="intensity-circle bar-shimmer" id="intensityCircle">
+                  <svg class="intensity-svg" viewBox="0 0 120 120">
+                    <circle cx="60" cy="60" r="54" class="intensity-bg"></circle>
+                    <circle
+                      cx="60"
+                      cy="60"
+                      r="54"
+                      class="intensity-progress"
+                      id="intensityProgress"
+                    ></circle>
+                  </svg>
+                  <div class="intensity-value" id="intensityValue">0%</div>
+                </div>
                 <div class="intensity-label" id="intensityLabel">
                   👤 Errant du Néant
                 </div>
-              </div>
-              <div class="intensity-bar">
-                <div class="intensity-fill" id="intensityFill"></div>
               </div>
             </div>
 

--- a/script.js
+++ b/script.js
@@ -2942,23 +2942,26 @@ class MyRPGLifeApp {
     const rate = this.calculateIntensityRate();
     const valueEl = document.getElementById('intensityValue');
     const labelEl = document.getElementById('intensityLabel');
-    const fillEl = document.getElementById('intensityFill');
+    const progressEl = document.getElementById('intensityProgress');
 
-    if (!valueEl || !labelEl || !fillEl) return;
+    if (!valueEl || !labelEl || !progressEl) return;
 
     const level = INTENSITY_LEVELS.find(l => rate >= l.min && rate <= l.max) || INTENSITY_LEVELS[0];
     const card = document.getElementById('intensityCard');
 
     valueEl.textContent = `${rate}%`;
     labelEl.textContent = `${level.emoji} ${level.title}`;
-    fillEl.style.width = `${Math.min(rate, 100)}%`;
-    fillEl.style.background = level.color;
-    fillEl.classList.add('bar-shimmer');
+
+    const circumference = 2 * Math.PI * 54;
+    const offset = circumference - (Math.min(rate, 100) / 100) * circumference;
+    progressEl.style.strokeDasharray = circumference;
+    progressEl.style.strokeDashoffset = offset;
+    progressEl.style.stroke = level.color;
 
     const base = extractBaseColor(level.color);
     const light = lightenColor(base, 30);
     card.style.setProperty('--intensity-color', base);
-    fillEl.style.boxShadow = `0 0 10px ${light}`;
+    progressEl.style.filter = `drop-shadow(0 0 6px ${light})`;
     card.style.boxShadow = `0 0 15px ${light}`;
     valueEl.style.color = base;
 

--- a/styles.css
+++ b/styles.css
@@ -733,13 +733,15 @@ body {
 .intensity-display {
   text-align: center;
   margin-bottom: 1rem;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
 }
 
 .intensity-value {
   font-size: 2.5rem;
   font-weight: 900;
   font-family: 'Orbitron', monospace;
-  margin-bottom: 0.5rem;
   color: var(--intensity-color, var(--accent-color));
   text-shadow: 0 0 5px var(--intensity-color, var(--accent-color));
 }
@@ -749,32 +751,51 @@ body {
   font-size: 0.95rem;
 }
 
-.intensity-bar {
-  width: 100%;
-  height: 10px;
-  background: var(--accent-bg);
-  border-radius: 6px;
-  overflow: hidden;
+.intensity-circle {
   position: relative;
+  width: 120px;
+  height: 120px;
+  margin-bottom: 0.5rem;
 }
 
-.intensity-fill {
+.intensity-svg {
+  width: 100%;
   height: 100%;
-  background: var(--gradient-secondary);
-  border-radius: 6px;
-  transition: width 0.5s ease;
-  width: 0%;
-  position: relative;
-  background-size: 200% auto;
+  transform: rotate(-90deg);
+}
+
+.intensity-bg {
+  fill: none;
+  stroke: var(--accent-bg);
+  stroke-width: 8;
+}
+
+.intensity-progress {
+  fill: none;
+  stroke: var(--intensity-color, var(--accent-color));
+  stroke-width: 8;
+  stroke-linecap: round;
+  stroke-dasharray: 339.292;
+  stroke-dashoffset: 339.292;
+  transition: stroke-dashoffset 0.5s ease;
+  filter: drop-shadow(0 0 6px var(--intensity-color, var(--accent-color)));
+}
+
+.intensity-circle .intensity-value {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
 }
 
 .bar-shimmer::after {
   content: '';
   position: absolute;
   inset: 0;
-  background: linear-gradient(90deg, transparent 0%, rgba(255,255,255,0.4) 50%, transparent 100%);
+  background: linear-gradient(90deg, transparent 0%, rgba(255,255,255,0.2) 50%, transparent 100%);
   background-size: 200% 100%;
-  animation: shimmerMove 4s linear infinite;
+  animation: shimmerMove 8s linear infinite;
+  border-radius: inherit;
 }
 
 @keyframes shimmerMove {


### PR DESCRIPTION
## Summary
- switch intensity bar to a circular progress indicator
- style the new circular meter with a soft, slow shimmer
- update script to drive the circular progress stroke

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68816ffd94e48332bb89e16017d74a55